### PR TITLE
(feat) Furnace integration.

### DIFF
--- a/src/iron/mod.rs
+++ b/src/iron/mod.rs
@@ -30,10 +30,16 @@ impl<'a, Rq: Request, Rs: Response<'a>, F: Furnace<'a, Rq, Rs>>
         self.furnace.smelt(ingot);
     }
 
-    pub fn listen(mut self, ip: IpAddr, port: u16) {
-        self.ip = ip;
-        self.port = port;
+    pub fn listen(self) {
         self.serve_forever();
+    }
+
+    pub fn from_furnace<Rq, Rs, F>(furnace: F, ip: IpAddr, port: u16) -> Iron<Rq, Rs, F> {
+        Iron {
+            furnace: furnace,
+            ip: ip,
+            port: port
+        }
     }
 }
 


### PR DESCRIPTION
- Implements `smelt` for `Iron`.
- Implements `Iron::from_furnace`.
  - Moves `ip` and `port` parameters to `Iron` constructor. They should be in `listen` as `Option`s, but cannot be until the `Option` fields are implemented.
