### PR TITLE
Solved the Great Response Crisis of Week 8

### DIFF
--- a/src/furnace/ironfurnace.rs
+++ b/src/furnace/ironfurnace.rs
@@ -10,18 +10,18 @@ use super::Furnace;
 /// then, when it hits an `Ingot` which returns `Unwind`, it will
 /// pass the request back up through all `Ingots` it has hit
 /// so far.
-pub struct IronFurnace<'a, 'b, Rq, Rs> {
+pub struct IronFurnace<Rq, Rs> {
     /// The storage used by `IronFurnace` to hold all Ingots
     /// that have been smelted on to it.
-    stack: Vec<Box<Ingot<'a, 'b, Rq, Rs>: Send>>
+    stack: Vec<Box<Ingot<Rq, Rs>: Send>>
 }
 
-impl<'a, 'b, Rq: Request, Rs: Response<'a, 'b>> Clone for IronFurnace<'a, 'b, Rq, Rs> {
-    fn clone(&self) -> IronFurnace<'a, 'b, Rq, Rs> { IronFurnace { stack: self.stack.clone() } }
+impl<Rq: Request, Rs: Response> Clone for IronFurnace<Rq, Rs> {
+    fn clone(&self) -> IronFurnace<Rq, Rs> { IronFurnace { stack: self.stack.clone() } }
 }
 
 /// `IronFurnace` is a `Furnace`
-impl<'a, 'b, Rq: Request, Rs: Response<'a, 'b>> Furnace<'a, 'b, Rq, Rs> for IronFurnace<'a, 'b, Rq, Rs> {
+impl<Rq: Request, Rs: Response> Furnace<Rq, Rs> for IronFurnace<Rq, Rs> {
     fn forge(&mut self, request: &mut Rq, response: &mut Rs, opt_alloy: Option<&mut Alloy>) {
         // Create a placeholder alloy.
         let mut alloy = &mut Alloy::new();
@@ -56,7 +56,7 @@ impl<'a, 'b, Rq: Request, Rs: Response<'a, 'b>> Furnace<'a, 'b, Rq, Rs> for Iron
         }
     }
     /// Add an `Ingot` to the `Furnace`.
-    fn smelt<'a, 'b, I: Ingot<'a, 'b, Rq, Rs>>(&mut self, ingot: I) {
+    fn smelt<I: Ingot<Rq, Rs>>(&mut self, ingot: I) {
         self.stack.push(box ingot);
     }
 

--- a/src/furnace/mod.rs
+++ b/src/furnace/mod.rs
@@ -17,7 +17,7 @@ pub mod ironfurnace;
 /// they allow you to completely control the resolution of `Ingots`.
 ///
 /// The default `Furnace` used in `Iron` is the `IronFurnace`.
-pub trait Furnace<'a, 'b, Rq: Request, Rs: Response<'a, 'b>>: Send + Clone {
+pub trait Furnace<Rq: Request, Rs: Response>: Send + Clone {
     /// A `Furnace's` forge method will get called once per Request, and may be
     /// called either with or without an existing `Alloy`. `Forge` is responsible
     /// for delegating the request to the correct `Ingots` and in the correct
@@ -28,7 +28,7 @@ pub trait Furnace<'a, 'b, Rq: Request, Rs: Response<'a, 'b>>: Send + Clone {
     /// storage of `Ingots`. Different `Furnaces` may implement different behavior
     /// for smelt, but ideally an `Ingot` added here will be delegated to during
     /// Requests.
-    fn smelt<'a, 'b, I: Ingot<'a, 'b, Rq, Rs>>(&mut self, _ingot: I);
+    fn smelt<I: Ingot<Rq, Rs>>(&mut self, _ingot: I);
 
     /// Create a new instance of `Furnace`.
     /// If you are making your own furnace, you'll need to

--- a/src/ingot/mod.rs
+++ b/src/ingot/mod.rs
@@ -46,7 +46,7 @@ pub enum Status {
 /// This can either be an instance of that `Ingot` or some other type. Since
 /// the same `Alloy` is passed to all further `Ingots` in the `Furnace`, this
 /// scheme allows you to expose data or functionality to future `Ingots`.
-pub trait Ingot<'a, 'b, Rq: Request, Rs: Response<'a, 'b>>: Send + Clone {
+pub trait Ingot<Rq: Request, Rs: Response>: Send + Clone {
     /// `enter` is called for each `Ingot` in a `Furnace` as a client request
     /// comes down the stack. `Ingots` should expose data through `Alloy` and
     /// store any data that will persist through the request here.
@@ -73,6 +73,6 @@ pub trait Ingot<'a, 'b, Rq: Request, Rs: Response<'a, 'b>>: Send + Clone {
     fn clone_box(&self) -> Box<Ingot<Rq, Rs>> { box self.clone() as Box<Ingot<Rq, Rs>> }
 }
 
-impl<'a, 'b, Rq: Request, Rs: Response<'a, 'b>> Clone for Box<'a, 'b, Ingot<'a, 'b, Rq, Rs>> {
+impl<Rq: Request, Rs: Response> Clone for Box<Ingot<Rq, Rs>> {
     fn clone(&self) -> Box<Ingot<Rq, Rs>> { self.clone_box() }
 }


### PR DESCRIPTION
By coercing lifetimes instead of types and moving from_http to its own trait, we have
managed to both allow new Response representations and remove all the lifetimes from
everywhere.

Such is the power of Sundays.
