### PR TITLE
(refactor) Move TARGET in configure script.

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Determine target architecture
+TARGET=`rustc --version 2> /dev/null | awk '/host:/ { FS = " "; print $2 }'`
+
 # Update dependencies from git
 # $1: git
 #     The git uri from which to download the dependency
@@ -10,8 +13,6 @@
 # $4: build command
 #     The argument to pass to make (not required)
 updateDependency () {
-# Determine target architecture
-  TARGET=`rustc --version 2> /dev/null | awk '/host:/ { FS = " "; print $2 }'`
 # Fetch local copy (can be reset with make clean)
   git clone $1 deps/$2
 # Build dependency


### PR DESCRIPTION
This will allow TARGET to be exposed to future dependencies. This is probably a non-use case at this point, for Iron.

However, ingot-seed _does_ need this, so it should be made standardly across all copies of this script (including the **configure** repo).
