### PR TITLE
(feat) Added FromIterator bound to Chain

### DIFF
--- a/src/chain/stackchain.rs
+++ b/src/chain/stackchain.rs
@@ -76,6 +76,15 @@ impl Chain for StackChain {
     }
 }
 
+impl FromIterator<Box<Middleware + Send>> for StackChain {
+    fn from_iter<T: Iterator<Box<Middleware + Send>>>(mut iterator: T) -> StackChain {
+        StackChain {
+            stack: iterator.collect(),
+            exit_stack: vec![]
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     pub use super::*;


### PR DESCRIPTION
You can now easily collect into Chains from arbitrary iterators of
`Box<Middleware>`. This makes creating Chains of middleware dynamically
extremely easy.
