### PR TITLE
(fix) Updated Travis for cargo install script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - wget http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz -O - |
       sudo tar zxf - --strip-components 1 -C /usr/local
   - curl http://static.rust-lang.org/cargo-dist/cargo-nightly-linux.tar.gz |
-      sudo tar --strip-components 1 -C /usr -xzf -
+      sudo tar -C /usr -xzf - && sudo /usr/cargo-nightly/install.sh
 script:
   - cargo build -v
   - cargo test -v


### PR DESCRIPTION
Travis is failing. This should let it use cargo again to fix that, as cargo added an install script last night.

Fixes #100 

Note: @iron/dev-team, this is probably necessary for all of the core middleware as well.
