### PR TITLE
(feat) Embed a url::Url inside every Request.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ git = "https://github.com/chris-morgan/anymap.git"
 
 git = "https://github.com/reem/rust-http-content-type.git"
 
+[dependencies.url]
+
+git = "https://github.com/servo/rust-url.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate regex;
 extern crate contenttype;
 extern crate http;
 extern crate anymap;
+extern crate url;
 #[cfg(test)]
 extern crate test;
 


### PR DESCRIPTION
I've been playing around with putting a proper `Url` object inside every `Request`.

Unfortunately, we can't use the `Url` from `servo/rust-url` until `rust-http` starts using it. When I tried to I got weird name errors I couldn't resolve.

```
src/request.rs:36:26: 36:29 error: mismatched types: expected `url::Url` but found `url::Url` (expected struct url::Url but found struct url::Url)
src/request.rs:36                     url: url,
```

Mostly just want to see what you think of the host + path conversion. Don't merge yet.
