### PR TITLE
(fix) Disable doc tests.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Obligatory example:
 //!
-//! ```rust
+//! ```ignore
 //! #[deriving(Clone)]
 //! pub struct ResponseTime { entry: u64 }
 //!

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -137,7 +137,7 @@ impl Middleware for Box<Chain + Send> {
 ///
 /// For instance, you can FromFn to wrap a simple controller:
 ///
-/// ```
+/// ```ignore
 /// fn hello_world(...) -> Status { res.write(b"Hello World!"); Continue }
 ///
 /// server.chain.link(FromFn::new(hello_world));


### PR DESCRIPTION
The current code examples are killing the build, Cargo is trying to run them as doc tests.

We could make them functional, but that would require more imports and more boilerplate, and it doesn't seem worth it.
