### PR TITLE
(refactor) Response no longer stores http_res.

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -93,6 +93,6 @@ impl<C: Chain> http::Server for IronListener<C> {
         let _ = self.chain.borrow_mut().dispatch(&mut req, &mut res);
 
         // Write the response back to http_res
-        res.write_back();
+        res.write_back(http_res);
     }
 }


### PR DESCRIPTION
This makes initializing a Response with no unsafe code possible,
greatly increasing the ergonomics of testing.
