### PR TITLE
(fix) Handle Request::from_http fail gracefully.

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -86,7 +86,15 @@ impl<C: Chain> http::Server for IronListener<C> {
 
     fn handle_request(&self, http_req: HttpRequest, http_res: &mut HttpResponse) {
         // Create wrapper Request and Response
-        let mut req = Request::from_http(http_req).unwrap();
+        let mut req = match Request::from_http(http_req) {
+            Ok(req) => req,
+            Err(e) => {
+                error!("Error getting request: {}", e);
+                http_res.status = ::http::status::InternalServerError;
+                let _ = http_res.write(b"Internal Server Error");
+                return;
+            }
+        };
         let mut res = Response::from_http(http_res);
 
         // Dispatch the request

--- a/src/request.rs
+++ b/src/request.rs
@@ -41,10 +41,10 @@ impl Request {
     /// Create a request from an HttpRequest.
     ///
     /// This constructor consumes the HttpRequest.
-    pub fn from_http(req: HttpRequest) -> Option<Request> {
+    pub fn from_http(req: HttpRequest) -> Result<Request, String> {
         match req.request_uri {
             AbsoluteUri(url) => {
-                Some(Request {
+                Ok(Request {
                     url: url,
                     remote_addr: req.remote_addr,
                     headers: req.headers,
@@ -58,15 +58,15 @@ impl Request {
                 // XXX: HTTPS incompatible, update when switching to Teepee.
                 let url_string = match req.headers.host {
                     Some(ref host) => format!("http://{}{}", host, path),
-                    None => return None
+                    None => return Err("No host specified in request".to_string())
                 };
 
                 let url = match Url::parse(url_string.as_slice()) {
                     Ok(url) => url,
-                    Err(_) => return None // Very unlikely.
+                    Err(e) => return Err(format!("Couldn't parse requested URL: {}", e))
                 };
 
-                Some(Request {
+                Ok(Request {
                     url: url,
                     remote_addr: req.remote_addr,
                     headers: req.headers,
@@ -75,7 +75,7 @@ impl Request {
                     alloy: Alloy::new()
                 })
             },
-            _ => None
+            _ => Err("Unsupported request URI".to_string())
         }
     }
 }


### PR DESCRIPTION
Request::from_http returns an Option<Request>. The main handle_request function calls Request::from_http, and unwraps it without checking if it failed or not. This leads to a 'task X failed at ...' in some cases (like when an HTTP 1.0 request is sent without a Host header).

I fixed this by making from_http return a Result instead of an Option to get more info about the failure, and then gracefully (at least compared to how it was) handle the failure in handle_request when it occurs.
