### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 env:
   - LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/rustlib/x86_64-unknown-linux-gnu/lib/
 install:
-  - curl www.rust-lang.org/rustup.sh | sudo bash
+  - curl https://static.rust-lang.org/rustup.sh | sudo bash
 script:
   - cargo build -v
   - cargo test -v


### PR DESCRIPTION
Now that HTTPS has landed for static.rust-lang.org and rustup.sh has moved there, we should access the rustup over HTTPS.
