### PR TITLE
(feat) Add a URL wrapper type.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,8 @@ extern crate regex;
 extern crate contenttype;
 extern crate http;
 extern crate anymap;
-extern crate url;
+// Rename the URL crate to avoid clashes with the `url` module.
+extern crate rust_url = "url";
 #[cfg(test)]
 extern crate test;
 
@@ -69,9 +70,12 @@ pub use chain::stackchain::StackChain;
 
 pub use alloy::Alloy;
 
+pub use url::Url;
+
 mod request;
 mod response;
 mod middleware;
 mod alloy;
 mod chain;
 mod iron;
+mod url;

--- a/src/request.rs
+++ b/src/request.rs
@@ -15,10 +15,7 @@ use super::alloy::Alloy;
 /// an `Alloy` for data communication between middleware.
 ///
 pub struct Request {
-    /// The requested url as a `url::Url`.
-    ///
-    /// See `servo/rust-url`'s documentation for more information.  
-    /// Useful methods include `Url::host`, `Url::domain` and `Url::query_pairs`.
+    /// The requested URL.
     pub url: Url,
 
     /// The originating address of the request.
@@ -44,6 +41,11 @@ impl Request {
     pub fn from_http(req: HttpRequest) -> Result<Request, String> {
         match req.request_uri {
             AbsoluteUri(url) => {
+                let url = match Url::from_generic_url(url) {
+                    Ok(url) => url,
+                    Err(e) => return Err(e)
+                };
+
                 Ok(Request {
                     url: url,
                     remote_addr: req.remote_addr,

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,142 @@
+//! HTTP/HTTPS URL type for Iron.
+
+use rust_url;
+use rust_url::{Host, RelativeSchemeData,};
+use rust_url::{whatwg_scheme_type_mapper, RelativeScheme};
+
+/// HTTP/HTTPS URL type for Iron.
+#[deriving(PartialEq, Eq, Clone)]
+pub struct Url {
+    /// The lower-cased scheme of the URL, typically "http" or "https".
+    pub scheme: String,
+
+    /// The host field of the URL, probably a domain.
+    pub host: Host,
+
+    /// The connection port.
+    pub port: u16,
+
+    /// The URL path, the resource to be accessed.
+    ///
+    /// A *non-empty* vector encoding the parts of the URL path.
+    /// Empty entries of `""` correspond to trailing slashes.
+    pub path: Vec<String>,
+
+    /// The URL username field, from the userinfo section of the URL.
+    ///
+    /// `None` if the `@` character was not part of the input OR
+    /// if a blank username was provided.
+    /// Otherwise, a non-empty string.
+    pub username: Option<String>,
+
+    /// The URL password field, from the userinfo section of the URL.
+    ///
+    /// `None` if the `@` character was not part of the input OR
+    /// if a blank password was provided.
+    /// Otherwise, a non-empty string.
+    pub password: Option<String>,
+
+    /// The URL query string.
+    ///
+    /// `None` if the `?` character was not part of the input.
+    /// Otherwise, a possibly empty, percent encoded string.
+    pub query: Option<String>,
+
+    /// The URL fragment.
+    ///
+    /// `None` if the `#` character was not part of the input.
+    /// Otherwise, a possibly empty, percent encoded string.
+    pub fragment: Option<String>
+}
+
+impl Url {
+    /// Create a URL from a string.
+    ///
+    /// The input must be a valid URL in a relative scheme for this to succeed.
+    ///
+    /// HTTP and HTTPS are relative schemes.
+    ///
+    /// See: http://url.spec.whatwg.org/#relative-scheme
+    pub fn parse(input: &str) -> Result<Url, String> {
+        // Parse the string using rust-url, then convert.
+        match rust_url::Url::parse(input) {
+            Ok(raw_url) => Url::from_generic_url(raw_url),
+            Err(e) => Err(format!("{}", e))
+        }
+    }
+
+    /// Create a `Url` from a `rust-url` `Url`.
+    pub fn from_generic_url(raw_url: rust_url::Url) -> Result<Url, String> {
+        // Create an Iron URL by extracting the relative scheme data.
+        match raw_url.scheme_data {
+            RelativeSchemeData(data) => {
+                // Extract the port as a 16-bit unsigned integer.
+                let port: u16 = match data.port {
+                    // If explicitly defined, unwrap it.
+                    Some(port) => port,
+
+                    // Otherwise, use the scheme's default port.
+                    None => {
+                        match whatwg_scheme_type_mapper(raw_url.scheme.as_slice()) {
+                            RelativeScheme(port) => port,
+                            _ => return Err(format!("Invalid relative scheme: `{}`", raw_url.scheme))
+                        }
+                    }
+                };
+
+                // Map empty usernames to None.
+                let username = match data.username.as_slice() {
+                    "" => None,
+                    _ => Some(data.username)
+                };
+
+                // Map empty passwords to None.
+                let password = match data.password {
+                    None => None,
+                    Some(ref x) if x.as_slice().is_empty() => None,
+                    Some(password) => Some(password)
+                };
+
+                Ok(Url {
+                    scheme: raw_url.scheme,
+                    host: data.host,
+                    port: port,
+                    path: data.path,
+                    username: username,
+                    password: password,
+                    query: raw_url.query,
+                    fragment: raw_url.fragment
+                })
+            },
+            _ => Err(format!("Not a relative scheme: `{}`", raw_url.scheme))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Url;
+
+    #[test]
+    fn test_default_port() {
+        assert_eq!(Url::parse("http://example.com/wow").unwrap().port, 80u16);
+        assert_eq!(Url::parse("https://example.com/wow").unwrap().port, 443u16);
+    }
+
+    #[test]
+    fn test_explicit_port() {
+        assert_eq!(Url::parse("http://localhost:3097").unwrap().port, 3097u16);
+    }
+
+    #[test]
+    fn test_empty_username() {
+        assert!(Url::parse("http://@example.com").unwrap().username.is_none());
+        assert!(Url::parse("http://:password@example.com").unwrap().username.is_none());
+    }
+
+    #[test]
+    fn test_empty_password() {
+        assert!(Url::parse("http://michael@example.com").unwrap().password.is_none());
+        assert!(Url::parse("http://:@example.com").unwrap().password.is_none());
+    }
+}


### PR DESCRIPTION
Closes #130.

I went against URL convention slightly by making the username optional. I did this for consistency with the password field, and because I think the `Option<String>` approach is more in the spirit of Rust. Usage should still be quite smooth.

One strange implementation detail: I had to call the module something other than `url` in order to avoid name clashes with the `url` crate. Alternatively, we could rename the `url` crate.

``` rust
extern crate url_crate = "url";
```

TODO:
- Implement `Show`. This would be nice, but would require a bit of formatting code and duplication of `rust-url` functionality.
