### PR TITLE
fixed nanosecond to millisecond conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ impl Middleware for ResponseTime {
 
     fn exit(&mut self, _req: &mut Request, _res: &mut Response) -> Status {
         let delta = precise_time_ns() - self.entry_time;
-        println!("Request took: {} ms", (delta as f64) / 100000.0);
+        println!("Request took: {} ms", (delta as f64) / 1000000.0);
         Continue
     }
 }

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -24,7 +24,7 @@ impl Middleware for ResponseTime {
 
     fn exit(&mut self, _req: &mut Request, _res: &mut Response) -> Status {
         let delta = precise_time_ns() - self.entry_time;
-        println!("Request took: {} ms", (delta as f64) / 100000.0);
+        println!("Request took: {} ms", (delta as f64) / 1000000.0);
         Continue
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //!     fn exit(&mut self, _req: &mut Request, _res: &mut Response) -> Status {
 //!         let delta = precise_time_ns() - self.entry_time;
-//!         println!("Request took: {} ms", (delta as f64) / 100000.0);
+//!         println!("Request took: {} ms", (delta as f64) / 1000000.0);
 //!         Continue
 //!     }
 //! }


### PR DESCRIPTION
Conversion from nanoseconds to milliseconds, should be divide by 1 million.
