### PR TITLE
Make Request and Response extensible.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/lib.rs"
 
 git = "https://github.com/chris-morgan/rust-http.git"
 
-[dependencies.anymap]
+[dependencies.typemap]
 
-git = "https://github.com/chris-morgan/anymap.git"
+git = "https://github.com/reem/rust-typemap.git"
 
 [dependencies.content-type]
 
@@ -32,4 +32,3 @@ git = "https://github.com/servo/rust-url.git"
 [dependencies.plugin]
 
 git = "https://github.com/reem/rust-plugin.git"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,9 @@ extern crate regex;
 
 extern crate contenttype;
 extern crate http;
-extern crate anymap;
+extern crate typemap;
+extern crate plugin;
+
 // Rename the URL crate to avoid clashes with the `url` module.
 extern crate rust_url = "url";
 #[cfg(test)]
@@ -68,12 +70,12 @@ pub use middleware::{Middleware, Status, Continue, Unwind, Error, FromFn};
 pub use chain::Chain;
 pub use chain::stackchain::StackChain;
 
-pub use anymap::AnyMap;
-
-#[deprecated = "Alloy is deprecated - use AnyMap instead."]
-pub use anymap::AnyMap as Alloy;
-
 pub use url::Url;
+
+pub use typemap::TypeMap;
+
+// Expose `GetCached` as `Plugin` so users can do `use iron::Plugin`.
+pub use plugin::GetCached as Plugin;
 
 mod request;
 mod response;

--- a/src/request.rs
+++ b/src/request.rs
@@ -6,7 +6,8 @@ use http::server::request::{AbsoluteUri, AbsolutePath};
 use http::headers::request::HeaderCollection;
 use http::method::Method;
 
-use anymap::AnyMap;
+use typemap::TypeMap;
+use plugin::Extensible;
 use url::Url;
 
 pub use http::server::request::Request as HttpRequest;
@@ -15,7 +16,7 @@ pub use http::server::request::Request as HttpRequest;
 /// The `Request` given to all `Middleware`.
 ///
 /// Stores all the properties of the client's request plus
-/// an `AnyMap` for data communication between middleware.
+/// an `TypeMap` for data communication between middleware.
 pub struct Request {
     /// The requested URL.
     pub url: Url,
@@ -33,7 +34,7 @@ pub struct Request {
     pub method: Method,
 
     /// Extensible storage for data passed between middleware.
-    pub extensions: AnyMap
+    pub extensions: TypeMap
 }
 
 impl Request {
@@ -54,7 +55,7 @@ impl Request {
                     headers: req.headers,
                     body: req.body,
                     method: req.method,
-                    extensions: AnyMap::new()
+                    extensions: TypeMap::new()
                 })
             },
             AbsolutePath(path) => {
@@ -76,11 +77,22 @@ impl Request {
                     headers: req.headers,
                     body: req.body,
                     method: req.method,
-                    extensions: AnyMap::new()
+                    extensions: TypeMap::new()
                 })
             },
             _ => Err("Unsupported request URI".to_string())
         }
+    }
+}
+
+// Allow plugins to attach to requests.
+impl Extensible for Request {
+    fn extensions(&self) -> &TypeMap {
+        &self.extensions
+    }
+
+    fn extensions_mut(&mut self) -> &mut TypeMap {
+        &mut self.extensions
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,8 @@
 use std::io::{IoResult, File, MemReader};
 use std::path::BytesContainer;
 
-use anymap::AnyMap;
+use typemap::TypeMap;
+use plugin::Extensible;
 use http::status::{Status, InternalServerError, NotFound};
 use http::status::Ok as OkStatus;
 use http::headers::response::HeaderCollection;
@@ -29,9 +30,9 @@ pub struct Response {
     /// The response status-code.
     pub status: Option<Status>,
 
-    /// An AnyMap to be used as an extensible storage for data
+    /// A TypeMap to be used as an extensible storage for data
     /// associated with this Response.
-    pub extensions: AnyMap
+    pub extensions: TypeMap
 }
 
 impl Response {
@@ -41,7 +42,7 @@ impl Response {
             headers: http_res.headers.clone(),
             status: None, // Start with no response code.
             body: None, // Start with no body.
-            extensions: AnyMap::new()
+            extensions: TypeMap::new()
         }
     }
 
@@ -105,6 +106,17 @@ impl Response {
                 // Something is really, really wrong.
                 .map_err(|e| error!("Error writing error message: {}", e));
         });
+    }
+}
+
+// Allow plugins to attach to responses.
+impl Extensible for Response {
+    fn extensions(&self) -> &TypeMap {
+        &self.extensions
+    }
+
+    fn extensions_mut(&mut self) -> &mut TypeMap {
+        &mut self.extensions
     }
 }
 


### PR DESCRIPTION
Seems to work quite well.
### Unresolved Issues
- Exporting `plugin::GetCached` as `iron::Plugin` hides the implementations in the documentation. Possibly a `rustdoc` deficiency, I'll create an issue and see what happens.
- ~~Should we export `iron::TypeMap`?~~ Yes.
- ~~Is having a field _and_ a method called `extensions` a bad idea? The compiler seems fine with it, and I think it just means we can't use `Request::extensions` as a first-class function inside its own methods.~~ It's fine.
