### PR TITLE
(fix) Update content type crate name.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ git = "https://github.com/chris-morgan/rust-http.git"
 
 git = "https://github.com/reem/rust-typemap.git"
 
-[dependencies.content-type]
+[dependencies.content_type]
 
 git = "https://github.com/reem/rust-http-content-type.git"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ extern crate regex;
 #[cfg(test)] extern crate test;
 
 // Third party packages
-extern crate contenttype;
+extern crate content_type;
 extern crate http;
 extern crate typemap;
 extern crate plugin;

--- a/src/response.rs
+++ b/src/response.rs
@@ -12,7 +12,7 @@ use http::headers::content_type::MediaType;
 
 pub use http::server::response::ResponseWriter as HttpResponse;
 
-use contenttype::get_content_type;
+use content_type::get_content_type;
 
 /// The response representation given to `Middleware`
 pub struct Response {


### PR DESCRIPTION
contenttype => content_type

As per https://github.com/reem/rust-http-content-type/pull/1
