### PR TITLE
(cleanup) Removed old response methods.

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,9 +6,7 @@ use iron::{Iron, Request, Response, IronResult};
 use iron::status;
 
 fn hello_world(_: &mut Request) -> IronResult<Response> {
-    let mut res = Response::new();
-    let _ = res.serve(status::Ok, "Hello, world!");
-    Ok(res)
+    Ok(Response::with(status::Ok, "Hello world!"))
 }
 
 fn main() {

--- a/src/response.rs
+++ b/src/response.rs
@@ -80,12 +80,6 @@ impl Response {
         Ok(response)
     }
 
-    /// Write the `Status` and data to the `Response`.
-    pub fn serve<S: BytesContainer>(&mut self, status: Status, body: S) {
-        self.status = Some(status);
-        self.body = Some(box MemReader::new(body.container_as_bytes().to_vec()) as Box<Reader + Send>);
-    }
-
     // `write_back` is used to put all the data added to `self`
     // back onto an `HttpResponse` so that it is sent back to the
     // client.


### PR DESCRIPTION
These methods are no longer applicable because Response is now
constructed by a Handler rather than modified.

Fixes #158
