### PR TITLE
(feat) Re-export http::headers.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,9 @@ pub use typemap::TypeMap;
 pub use http::status;
 pub use http::method;
 
+// Headers
+pub use http::headers;
+
 // Expose `GetCached` as `Plugin` so users can do `use iron::Plugin`.
 pub use plugin::GetCached as Plugin;
 


### PR DESCRIPTION
Just another re-export to prevent users of Iron from
using rust-http directly.

Iron's headers should probably be refactored to be a wrapper.

Teepee's representation is really good, but we should probably
just wait until we can completely port over instead of cannibalizing
parts of its source.
