### PR TITLE
(feat) impl of Handler for |&:| closures.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@
 #![deny(missing_doc)]
 #![deny(warnings)]
 
-#![feature(macro_rules, phase, globs)]
+#![feature(macro_rules, phase, globs, unboxed_closure_sugar,
+           unboxed_closures, overloaded_calls)]
 //! The main crate for the Iron library.
 //!
 //! Iron is a high level web framework built in and for Rust.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -317,6 +317,18 @@ impl Handler for Arc<Box<Handler + Send + Sync>> {
     }
 }
 
+impl<'a> Handler for Box<Fn<(&'a mut Request,), IronResult<Response>> + Send + Sync> {
+    fn call(&self, req: &mut Request) -> IronResult<Response> {
+        use std::mem;
+
+        // FIXME: This transmute actually does nothing, but is needed
+        // because of the lack of higher kinded lifetimes.
+        //
+        // It can be removed when they are implemented.
+        (**self).call(( unsafe { mem::transmute(req) },))
+    }
+}
+
 impl BeforeMiddleware for fn(&mut Request) -> IronResult<()> {
     fn before(&self, req: &mut Request) -> IronResult<()> {
         (*self)(req)


### PR DESCRIPTION
Downsides: introduces an unsafe block into the Iron source, but since it does
nothing and is a temporary, unnecessary hack to work around the lack of higher-kinded
lifetimes, it's ok for now.
