### PR TITLE
(chore) Derive encodable for Url.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ extern crate regex;
 #[phase(plugin)] extern crate regex_macros;
 #[phase(plugin, link)] extern crate log;
 #[cfg(test)] extern crate test;
+extern crate serialize;
 
 // Third party packages
 extern crate content_type;

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -7,7 +7,7 @@ use rust_url::format::{PathFormatter, UserInfoFormatter};
 use std::fmt::{Show, Formatter, FormatError};
 
 /// HTTP/HTTPS URL type for Iron.
-#[deriving(PartialEq, Eq, Clone)]
+#[deriving(PartialEq, Eq, Clone, Encodable)]
 pub struct Url {
     /// The lower-cased scheme of the URL, typically "http" or "https".
     pub scheme: String,


### PR DESCRIPTION
Blocking on servo/rust-url#27
