### PR TITLE
(cleanup) Remove regex dependendencies.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@
 //! ```
 
 // Stdlib dependencies
-extern crate regex;
-#[phase(plugin)] extern crate regex_macros;
 #[phase(plugin, link)] extern crate log;
 #[cfg(test)] extern crate test;
 


### PR DESCRIPTION
These are still linked, but are unused.
