### PR TITLE
(fix): Removed unused variables in the middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -321,7 +321,7 @@ mod helpers {
     pub fn run_befores(req: &mut Request, befores: &[Box<BeforeMiddleware>], err: Option<IronError>) -> IronResult<()> {
         match err {
             Some(mut e) => {
-                for (i, before) in befores.iter().enumerate() {
+                for before in befores.iter() {
                     match before.catch(req, e) {
                         Ok(_) => return run_befores(req, befores, None),
                         Err(new) => e = new
@@ -346,7 +346,7 @@ mod helpers {
                   afters: &[Box<AfterMiddleware>]) -> IronResult<Response> {
         match err {
             Some(mut e) => {
-                for (i, after) in afters.iter().enumerate() {
+                for after in afters.iter() {
                     match after.catch(req, &mut res, e) {
                         Ok(_) => return run_afters(req, res, None, afters),
                         Err(new) => e = new


### PR DESCRIPTION
I wanted to play around with Iron and Rust (for the first time) but I've encountered compilation problem on current rust nightly (OS X).

Error: 

``` bash
arathunku@pc->arathunku-iron@bug/unused-variables*$ cargo -V
cargo 0.0.1-pre-nightly (29e6a4f 2014-09-17 20:15:50 +0000)
```

``` bash
arathunku@pc->arathunku-iron@bug/unused-variables*$ rustc -v
rustc 0.12.0-nightly (af3889f69 2014-09-18 21:20:38 +0000)
```

```
arathunku@pc->arathunku-iron@bug/unused-variables*$ cargo build --verbose
       Fresh phantom v0.0.0 (https://github.com/reem/rust-phantom.git#deb5acfe)
       Fresh encoding v0.1.0 (https://github.com/lifthrasiir/rust-encoding#35f0d70f)
       Fresh openssl v0.0.0 (https://github.com/sfackler/rust-openssl.git#cc7511a3)
       Fresh replace-map v0.0.1 (https://github.com/reem/rust-replace-map.git#2bbe0c93)
       Fresh unsafe-any v0.1.0 (https://github.com/reem/rust-unsafe-any.git#75cff194)
       Fresh typeable v0.0.1 (https://github.com/reem/rust-typeable.git#55154e18)
       Fresh url v0.1.0 (https://github.com/servo/rust-url.git#bfdf8093)
       Fresh typemap v0.0.0 (https://github.com/reem/rust-typemap.git#895f26e2)
       Fresh error v0.0.0 (https://github.com/reem/rust-error.git#5aaaa164)
       Fresh http v0.1.0-pre (https://github.com/chris-morgan/rust-http.git#c1d601c1)
       Fresh plugin v0.0.0 (https://github.com/reem/rust-plugin.git#19b97b79)
       Fresh content_type v0.1.0 (https://github.com/reem/rust-http-content-type.git#635e92b7)
   Compiling iron v0.0.1 (file:///Users/arathunku/dev/rust-projects/arathunku-iron)
     Running `rustc src/lib.rs --crate-name iron --crate-type lib -g -C metadata=bd32726e1dcee1cf -C extra-filename=-bd32726e1dcee1cf --out-dir /Users/arathunku/dev/rust-projects/arathunku-iron/target --dep-info /Users/arathunku/dev/rust-projects/arathunku-iron/target/.fingerprint/iron-bd32726e1dcee1cf/dep-lib-iron -L /Users/arathunku/dev/rust-projects/arathunku-iron/target -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/deps -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/native/http-b27c1e7938f5a5d0 -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/native/content_type-b3fc4f01bc3dcbfb --extern http=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libhttp-b27c1e7938f5a5d0.rlib --extern error=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/liberror-e5e02eafec1ab2f1.rlib --extern plugin=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libplugin-f845a6ab531c9346.rlib --extern content_type=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libcontent_type-b3fc4f01bc3dcbfb.rlib --extern replace-map=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libreplace-map-d1de898a4eb569a5.rlib --extern url=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/liburl-921578b148f50e06.rlib --extern typemap=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libtypemap-3fdac74be380d9e4.rlib`
src/middleware.rs:324:22: 324:23 error: unused variable: `i`, #[deny(unused_variable)] on by default
src/middleware.rs:324                 for (i, before) in befores.iter().enumerate() {
                                           ^
src/middleware.rs:349:22: 349:23 error: unused variable: `i`, #[deny(unused_variable)] on by default
src/middleware.rs:349                 for (i, after) in afters.iter().enumerate() {
                                           ^
error: aborting due to 2 previous errors
Could not compile `iron`.

Caused by:
  Process didn't exit successfully: `rustc src/lib.rs --crate-name iron --crate-type lib -g -C metadata=bd32726e1dcee1cf -C extra-filename=-bd32726e1dcee1cf --out-dir /Users/arathunku/dev/rust-projects/arathunku-iron/target --dep-info /Users/arathunku/dev/rust-projects/arathunku-iron/target/.fingerprint/iron-bd32726e1dcee1cf/dep-lib-iron -L /Users/arathunku/dev/rust-projects/arathunku-iron/target -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/deps -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/native/http-b27c1e7938f5a5d0 -L /Users/arathunku/dev/rust-projects/arathunku-iron/target/native/content_type-b3fc4f01bc3dcbfb --extern http=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libhttp-b27c1e7938f5a5d0.rlib --extern error=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/liberror-e5e02eafec1ab2f1.rlib --extern plugin=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libplugin-f845a6ab531c9346.rlib --extern content_type=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libcontent_type-b3fc4f01bc3dcbfb.rlib --extern replace-map=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libreplace-map-d1de898a4eb569a5.rlib --extern url=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/liburl-921578b148f50e06.rlib --extern typemap=/Users/arathunku/dev/rust-projects/arathunku-iron/target/deps/libtypemap-3fdac74be380d9e4.rlib` (status=101)
```
