### PR TITLE
Expose the `Assoc` trait through `typemap`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub use middleware::{BeforeMiddleware, AfterMiddleware, AroundMiddleware,
 pub use iron::Iron;
 
 // Extensions
-pub use typemap::TypeMap;
+pub use typemap::{mod, TypeMap};
 
 // Status codes and Methods.
 pub use http::status;


### PR DESCRIPTION
This will allow code like `use iron::typemap::Assoc` which is needed in order to work with `TypeMap`
