### PR TITLE
(fix) Call the main handlers catch method.

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -89,7 +89,9 @@ impl<H: Handler> http::Server for IronListener<H> {
         };
 
         // Dispatch the request
-        let res = self.handler.call(&mut req);
+        let res = self.handler.call(&mut req).map_err(|e| {
+            self.handler.catch(&mut req, e)
+        });
 
         match res {
             // Write the response back to http_res


### PR DESCRIPTION
Right now errors in the main handler are immediately assumed
to be unhandleable. This changes the behavior of Iron to call
the catch method.

The interaction with chain's catch method is unresolved.
