### PR TITLE
Allow Iron URLs to convert to rust-url URLs.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![deny(missing_doc)]
 #![deny(warnings)]
 
-#![feature(macro_rules, phase, globs, unboxed_closures)]
+#![feature(macro_rules, phase, globs, unboxed_closures, slicing_syntax)]
 //! The main crate for the Iron library.
 //!
 //! Iron is a high level web framework built in and for Rust.


### PR DESCRIPTION
I've added a method to convert our custom URL type to a `rust-url::Url`.

It takes `self` by value rather than reference, as inner fields need cloning anyway. This way we can do both:

``` rust
// Original url no longer valid.
let rust_url = url.into_generic_url();

// Original url still valid.
let rust_url = url.clone().into_generic_url();
```

Relevant: https://github.com/iron/iron/pull/197
