### PR TITLE
(fix) Remove usage of replace_map.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,3 @@ git = "https://github.com/reem/rust-plugin.git"
 
 git = "https://github.com/reem/rust-error.git"
 
-[dependencies.replace-map]
-
-git = "https://github.com/reem/rust-replace-map.git"
-

--- a/examples/around.rs
+++ b/examples/around.rs
@@ -42,7 +42,7 @@ impl<H: Handler> Handler for LoggerHandler<H> {
 }
 
 impl AroundMiddleware for Logger {
-    fn around<H>(self, handler: H) -> Box<Handler + Send + Sync> where H: Handler {
+    fn around(self, handler: Box<Handler + Send + Sync>) -> Box<Handler + Send + Sync> {
         box LoggerHandler {
             logger: self,
             handler: handler
@@ -55,9 +55,9 @@ fn hello_world(_: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    let tiny = Iron::new(Logger::new(Tiny).around(hello_world));
-    let silent = Iron::new(Logger::new(Silent).around(hello_world));
-    let large = Iron::new(Logger::new(Large).around(hello_world));
+    let tiny = Iron::new(Logger::new(Tiny).around(box hello_world));
+    let silent = Iron::new(Logger::new(Silent).around(box hello_world));
+    let large = Iron::new(Logger::new(Large).around(box hello_world));
 
     tiny.listen(Ipv4Addr(127, 0, 0, 1), 2000);
     silent.listen(Ipv4Addr(127, 0, 0, 1), 3000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ extern crate "typemap" as tmap;
 extern crate plugin;
 extern crate error;
 extern crate "url" as rust_url;
-extern crate "replace-map" as rmap;
 
 // Request + Response
 pub use request::{Request, Url};


### PR DESCRIPTION
Replace-map is unsafe in the presence of exceptions,
so its use must be removed. Instead, the internal
representation of Chain now uses a mostly-always-Some
Option to store its Handler.

Additionally, to simplify the ecosystem, AroundMiddleware
has been modified to receive and return
Box<Handler + Send + Sync>.

[breaking-change]
