### PR TITLE
Use ToSocketAddr to allow the string form of a network address

### DIFF
--- a/examples/404.rs
+++ b/examples/404.rs
@@ -1,8 +1,6 @@
 #![feature(globs)]
 extern crate iron;
 
-use std::io::net::ip::Ipv4Addr;
-
 use iron::prelude::*;
 use iron::response::modifiers::Status;
 use iron::status;
@@ -13,7 +11,7 @@ fn fourzerofour(_: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    Iron::new(fourzerofour).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
+    Iron::new(fourzerofour).listen("localhost:3000").unwrap();
     println!("On 3000");
 }
 

--- a/examples/around.rs
+++ b/examples/around.rs
@@ -7,8 +7,6 @@ use iron::{Handler, AroundMiddleware};
 use iron::response::modifiers::{Status, Body};
 use iron::status;
 
-use std::io::net::ip::Ipv4Addr;
-
 enum LoggerMode {
     Silent,
     Tiny,
@@ -64,9 +62,9 @@ fn main() {
     let silent = Iron::new(Logger::new(LoggerMode::Silent).around(box hello_world));
     let large = Iron::new(Logger::new(LoggerMode::Large).around(box hello_world));
 
-    tiny.listen(Ipv4Addr(127, 0, 0, 1), 2000).unwrap();
-    silent.listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
-    large.listen(Ipv4Addr(127, 0, 0, 1), 4000).unwrap();
+    tiny.listen("localhost:2000").unwrap();
+    silent.listen("localhost:3000").unwrap();
+    large.listen("localhost:4000").unwrap();
 
     println!("Servers listening on 2000, 3000, and 4000");
 }

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -3,7 +3,6 @@
 extern crate iron;
 extern crate time;
 
-use std::io::net::ip::Ipv4Addr;
 use iron::prelude::*;
 use iron::{Handler, BeforeMiddleware, ChainBuilder};
 use iron::response::modifiers::{Status, Body};
@@ -39,7 +38,7 @@ fn main() {
     // Link our error maker.
     chain.link_before(ErrorProducer);
 
-    Iron::new(chain).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
+    Iron::new(chain).listen("localhost:3000").unwrap();
     println!("On 3000");
 }
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -3,7 +3,6 @@ extern crate iron;
 
 use iron::prelude::*;
 
-use std::io::net::ip::Ipv4Addr;
 use iron::response::modifiers::{Status, Body};
 use iron::status;
 
@@ -14,7 +13,7 @@ fn hello_world(_: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    Iron::new(hello_world).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
+    Iron::new(hello_world).listen("localhost:3000").unwrap();
     println!("On 3000");
 }
 

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -1,7 +1,6 @@
 #![feature(globs)]
 extern crate iron;
 
-use std::io::net::ip::Ipv4Addr;
 use iron::prelude::*;
 use iron::response::modifiers::{Status, Redirect};
 use iron::{Url, status};
@@ -14,7 +13,7 @@ fn redirect(_: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    Iron::new(redirect).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
+    Iron::new(redirect).listen("localhost:3000").unwrap();
     println!("On 3000");
 }
 

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -2,8 +2,6 @@
 extern crate iron;
 extern crate time;
 
-use std::io::net::ip::Ipv4Addr;
-
 use iron::prelude::*;
 use iron::{BeforeMiddleware, AfterMiddleware, ChainBuilder, typemap};
 use iron::response::modifiers::{Status, Body};
@@ -38,5 +36,5 @@ fn main() {
     let mut chain = ChainBuilder::new(hello_world);
     chain.link_before(ResponseTime);
     chain.link_after(ResponseTime);
-    Iron::new(chain).listen(Ipv4Addr(127, 0, 0, 1), 3000).unwrap();
+    Iron::new(chain).listen("localhost:3000").unwrap();
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,3 +42,18 @@ impl Error for HyperError {
     }
 }
 
+/// Occurs when the address to listen on is not valid.
+#[deriving(Show)]
+pub struct InvalidAddressError(pub IoError);
+
+impl InvalidAddressError {
+    /// Create a new InvalidAddressError.
+    pub fn new(err: IoError) -> InvalidAddressError { InvalidAddressError(err) }
+}
+
+impl Error for InvalidAddressError {
+    fn name(&self) -> &'static str {
+        let InvalidAddressError(ref err) = *self;
+        err.desc
+    }
+}


### PR DESCRIPTION
Using the `ToSocketAddr` trait, we can eliminate the need to import `Ipv4Addr` every time.
