### PR TITLE
(fix) changed std::fmt::FormatError to std::fmt::Error

### DIFF
--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Request representation and associated methods.
 
 use std::io::net::ip::SocketAddr;
-use std::fmt::{Show, Formatter, FormatError};
+use std::fmt::{Show, Formatter, Error};
 
 use http::server::request::{AbsoluteUri, AbsolutePath};
 use http::headers::request::HeaderCollection;
@@ -41,7 +41,7 @@ pub struct Request {
 }
 
 impl Show for Request {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         try!(writeln!(f, "Request {{"));
 
         try!(writeln!(f, "    url: {}", self.url));

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -4,7 +4,7 @@ use rust_url;
 use rust_url::{Host, RelativeSchemeData, UrlRelativeSchemeData};
 use rust_url::{whatwg_scheme_type_mapper, RelativeScheme};
 use rust_url::format::{PathFormatter, UserInfoFormatter};
-use std::fmt::{Show, Formatter, FormatError};
+use std::fmt::{Show, Formatter, Error};
 
 use {serialize};
 
@@ -139,7 +139,7 @@ impl Url {
 }
 
 impl Show for Url {
-    fn fmt<'a>(&self, formatter: &mut Formatter) -> Result<(), FormatError> {
+    fn fmt<'a>(&self, formatter: &mut Formatter) -> Result<(), Error> {
         // Write the scheme.
         try!(self.scheme.fmt(formatter));
         try!("://".fmt(formatter));

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -2,7 +2,7 @@
 
 use std::io::{mod, File, MemReader};
 use std::path::BytesContainer;
-use std::fmt::{Show, Formatter, FormatError};
+use std::fmt::{Show, Formatter, Error};
 
 use typemap::TypeMap;
 use plugin::Extensible;
@@ -169,7 +169,7 @@ impl Response {
 }
 
 impl Show for Response {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), FormatError> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         try!(writeln!(f, "Response {{"));
 
         try!(writeln!(f, "    status: {}", self.status));


### PR DESCRIPTION
Rust must have recently changed std::fmt.
The project wouldn't build for me until I changed this.
