### PR TITLE
(fix) Pin to working versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ name = "iron"
 path = "src/lib.rs"
 
 [dependencies]
-hyper = "*"
-typemap = "*"
-url = "*"
-plugin = "*"
-modifier = "*"
-error = "*"
+hyper = "0.0.14"
+typemap = "0.0.4"
+url = "0.2.6"
+plugin = "0.0.2"
+modifier = "0.0.3"
+error = "0.0.2"
 


### PR DESCRIPTION
Hey y'all... Iron is a cool project and I understand stuff is moving fast in Rust land, but I've been trying on and off for weeks to get an example compiled so I can try Iron out, and it's literally never worked! There is always some dependency out of sync with another.

Today, I was able to hack around the only brokenness by manually changing the version of `error` in my project's Cargo.lock from 0.0.3 to 0.0.2.

It would be cool if you'd require specific, working versions of dependencies (as I've done here) to increase the chance that people can get this to compile. Cheers.
