### PR TITLE
Update to rust nightly 2015-01-09

### DIFF
--- a/examples/around.rs
+++ b/examples/around.rs
@@ -43,11 +43,11 @@ impl<H: Handler> Handler for LoggerHandler<H> {
 
 impl AroundMiddleware for Logger {
     fn around(self, handler: Box<Handler + Send + Sync>) -> Box<Handler + Send + Sync> {
-        box LoggerHandler {
+        Box::new(LoggerHandler {
             logger: self,
             handler: handler
         } as Box<Handler + Send + Sync>
-    }
+    })
 }
 
 fn hello_world(_: &mut Request) -> IronResult<Response> {
@@ -55,9 +55,9 @@ fn hello_world(_: &mut Request) -> IronResult<Response> {
 }
 
 fn main() {
-    let tiny = Iron::new(Logger::new(LoggerMode::Tiny).around(box hello_world));
-    let silent = Iron::new(Logger::new(LoggerMode::Silent).around(box hello_world));
-    let large = Iron::new(Logger::new(LoggerMode::Large).around(box hello_world));
+    let tiny = Iron::new(Logger::new(LoggerMode::Tiny).around(Box::new(hello_world)));
+    let silent = Iron::new(Logger::new(LoggerMode::Silent).around(Box::new(hello_world)));
+    let large = Iron::new(Logger::new(LoggerMode::Large).around(Box::new(hello_world)));
 
     tiny.listen("localhost:2000").unwrap();
     silent.listen("localhost:3000").unwrap();

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -33,7 +33,7 @@ impl Handler for ErrorHandler {
 
 impl BeforeMiddleware for ErrorProducer {
     fn before(&self, _: &mut Request) -> IronResult<()> {
-        Err(box StringError("Error".to_string()) as IronError)
+        Err(Box::new(StringError("Error".to_string()) as IronError))
     }
 }
 

--- a/src/iron.rs
+++ b/src/iron.rs
@@ -39,7 +39,7 @@ impl<H: Handler> Iron<H> {
     }
 
     /// Kick off the server process with X threads.
-    pub fn listen_with<A: ToSocketAddr>(self, addr: A, threads: uint) -> IronResult<Listening> {
+    pub fn listen_with<A: ToSocketAddr>(self, addr: A, threads: usize) -> IronResult<Listening> {
         let SocketAddr { ip, port } = try!(addr.to_socket_addr());
 
         Ok(try!(Server::http(ip, port).listen_threads(self, threads)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(missing_docs)]
 #![deny(warnings)]
 
-#![feature(macro_rules, phase, globs, unboxed_closures, slicing_syntax, default_type_params)]
+#![feature(unboxed_closures, slicing_syntax)]
 
 //! The main crate for the Iron library.
 //!
@@ -22,7 +22,7 @@
 //! ```
 
 // Stdlib dependencies
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 #[cfg(test)] extern crate test;
 
 // Third party packages
@@ -52,7 +52,7 @@ pub use hyper::header::common as headers;
 pub use hyper::header::Headers;
 
 // Expose `GetCached` as `Plugin` so users can do `use iron::Plugin`.
-pub use plugin::GetCached as Plugin;
+pub use plugin::Pluggable as Plugin;
 
 // Expose modifiers.
 pub use modifier::Set;
@@ -88,7 +88,7 @@ pub mod prelude {
 
 /// Re-exports from the TypeMap crate.
 pub mod typemap {
-    pub use tmap::{TypeMap, Assoc};
+    pub use tmap::{TypeMap, Key};
 }
 
 /// Re-exports from the Modifier crate.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -205,7 +205,7 @@ impl ChainBuilder {
         ChainBuilder {
             befores: vec![],
             afters: vec![],
-            handler: Some(box handler as Box<Handler + Send + Sync>)
+            handler: Some(Box::new(handler as Box<Handler + Send + Sync>))
         }
     }
 }
@@ -215,23 +215,23 @@ impl Chain for ChainBuilder {
         ChainBuilder {
             befores: vec![],
             afters: vec![],
-            handler: Some(box handler as Box<Handler + Send + Sync>)
+            handler: Some(Box::new(handler as Box<Handler + Send + Sync>))
         }
     }
 
     fn link<B, A>(&mut self, link: (B, A))
     where A: AfterMiddleware, B: BeforeMiddleware {
         let (before, after) = link;
-        self.befores.push(box before as Box<BeforeMiddleware + Send + Sync>);
-        self.afters.push(box after as Box<AfterMiddleware + Send + Sync>);
+        self.befores.push(Box::new(before as Box<BeforeMiddleware + Send + Sync>));
+        self.afters.push(Box::new(after as Box<AfterMiddleware + Send + Sync>));
     }
 
     fn link_before<B>(&mut self, before: B) where B: BeforeMiddleware {
-        self.befores.push(box before as Box<BeforeMiddleware + Send + Sync>);
+        self.befores.push(Box::new(before as Box<BeforeMiddleware + Send + Sync>));
     }
 
     fn link_after<A>(&mut self, after: A) where A: AfterMiddleware {
-        self.afters.push(box after as Box<AfterMiddleware + Send + Sync>);
+        self.afters.push(Box::new(after as Box<AfterMiddleware + Send + Sync>));
     }
 
     fn around<A>(&mut self, around: A) where A: AroundMiddleware {

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Request representation and associated methods.
 
 use std::io::net::ip::SocketAddr;
-use std::fmt::{mod, Show};
+use std::fmt::{self, Show};
 
 use hyper::uri::RequestUri::{AbsoluteUri, AbsolutePath};
 use hyper::header::Headers;

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -2,9 +2,9 @@
 
 use url::{Host, RelativeSchemeData};
 use url::{whatwg_scheme_type_mapper};
-use url::{mod, SchemeData, SchemeType};
+use url::{self, SchemeData, SchemeType};
 use url::format::{PathFormatter, UserInfoFormatter};
-use std::fmt::{mod, Show};
+use std::fmt::{self, Show};
 
 /// HTTP/HTTPS URL type for Iron.
 #[deriving(PartialEq, Eq, Clone)]

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Response representation and associated methods.
 
-use std::io::{mod, IoResult};
-use std::fmt::{mod, Show};
+use std::io::{self, IoResult};
+use std::fmt::{self, Show};
 
 use typemap::TypeMap;
 use plugin::Extensible;
@@ -9,7 +9,7 @@ use modifier::{Set, Modifier};
 
 use hyper::header::Headers;
 
-use status::{mod, Status};
+use status::{self, Status};
 use {headers};
 
 pub use hyper::server::response::Response as HttpResponse;

--- a/src/response/modifiers.rs
+++ b/src/response/modifiers.rs
@@ -75,7 +75,7 @@ impl Bodyable for Vec<u8> {
     #[inline]
     fn set_body(self, res: &mut Response) {
         res.headers.set(headers::ContentLength(self.len()));
-        res.body = Some(box MemReader::new(self) as Box<Reader + Send>);
+        res.body = Some(Box::new(MemReader::new(self) as Box<Reader + Send>));
     }
 }
 
@@ -102,7 +102,7 @@ impl Bodyable for File {
         //     .and_then(|ct| {
         //         res.headers.set(headers::ContentType(ct))
         //     });
-        res.body = Some(box self as Box<Reader + Send>);
+        res.body = Some(Box::new(self as Box<Reader + Send>));
     }
 }
 


### PR DESCRIPTION
This fixes all but those errors:

src/response/modifiers.rs:37:1: 42:2 error: the type `mime::Mime` does not reference any types defined in this crate; only traits defined in the current crate can be implemented for arbitrary types [E0117]
src/response/modifiers.rs:37 impl Modifier<Response> for Mime {
src/response/modifiers.rs:38     #[inline]
src/response/modifiers.rs:39     fn modify(self, res: &mut Response) {
src/response/modifiers.rs:40         res.headers.set(headers::ContentType(self))
src/response/modifiers.rs:41     }
src/response/modifiers.rs:42 }
src/response/modifiers.rs:47:1: 52:2 error: type parameter `B` is not constrained by any local type; only traits defined in the current crate can be implemented for a type parameter
src/response/modifiers.rs:47 impl<B: Bodyable> Modifier<Response> for B {
src/response/modifiers.rs:48     #[inline]
src/response/modifiers.rs:49     fn modify(self, res: &mut Response) {
src/response/modifiers.rs:50         self.set_body(res);
src/response/modifiers.rs:51     }
src/response/modifiers.rs:52 }
src/response/modifiers.rs:47:1: 52:2 note: for a limited time, you can add `#![feature(old_orphan_check)]` to your crate to disable this rule
src/response/modifiers.rs:47 impl<B: Bodyable> Modifier<Response> for B {
src/response/modifiers.rs:48     #[inline]
src/response/modifiers.rs:49     fn modify(self, res: &mut Response) {
src/response/modifiers.rs:50         self.set_body(res);
src/response/modifiers.rs:51     }
src/response/modifiers.rs:52 }
src/response/modifiers.rs:122:1: 126:2 error: the type `hyper::status::StatusCode` does not reference any types defined in this crate; only traits defined in the current crate can be implemented for arbitrary types [E0117]
src/response/modifiers.rs:122 impl Modifier<Response> for status::Status {
src/response/modifiers.rs:123     fn modify(self, res: &mut Response) {
src/response/modifiers.rs:124         res.status = Some(self);
src/response/modifiers.rs:125     }
src/response/modifiers.rs:126 }
error: aborting due to 3 previous errors
Could not compile `iron`.