### PR TITLE
(fix) Update to the latest rustc (4874ca36f 2015-01-23)

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -7,12 +7,19 @@ use iron::{Handler, BeforeMiddleware, ChainBuilder};
 use iron::status;
 
 use std::error::Error;
+use std::fmt::{self, Debug};
 
 struct ErrorHandler;
 struct ErrorProducer;
 
-#[derive(Show)]
+#[derive(Debug)]
 struct StringError(String);
+
+impl fmt::Display for StringError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
 
 impl Error for StringError {
     fn description(&self) -> &str { &*self.0 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -338,7 +338,7 @@ mod helpers {
                 for (i, before) in befores.iter().enumerate() {
                     match before.before(req) {
                         Ok(_) => (),
-                        Err(err) => return run_befores(req, befores.slice_from(i), Some(err))
+                        Err(err) => return run_befores(req, &befores[i..], Some(err))
                     }
                 }
                 Ok(())
@@ -363,7 +363,7 @@ mod helpers {
                 for (i, after) in afters.iter().enumerate() {
                     match after.after(req, &mut res) {
                         Ok(_) => (),
-                        Err(err) => return run_afters(req, res, Some(err), afters.slice_from(i))
+                        Err(err) => return run_afters(req, res, Some(err), &afters[i..])
                     }
                 }
                 Ok(res)

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Request representation and associated methods.
 
 use std::io::net::ip::SocketAddr;
-use std::fmt::{self, Show};
+use std::fmt::{self, Debug};
 
 use hyper::uri::RequestUri::{AbsoluteUri, AbsolutePath};
 use hyper::header::Headers;
@@ -42,7 +42,7 @@ pub struct Request {
     pub extensions: TypeMap
 }
 
-impl Show for Request {
+impl Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(writeln!(f, "Request {{"));
 

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -7,7 +7,7 @@ use url::format::{PathFormatter, UserInfoFormatter};
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
-#[derive(PartialEq, Eq, Clone, Show)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Url {
     /// The lower-cased scheme of the URL, typically "http" or "https".
     pub scheme: String,
@@ -136,7 +136,7 @@ impl Url {
     }
 }
 
-impl fmt::String for Url {
+impl fmt::Display for Url {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         // Write the scheme.
         try!(self.scheme.fmt(formatter));

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Response representation and associated methods.
 
 use std::io::{self, IoResult};
-use std::fmt::{self, Show};
+use std::fmt::{self, Debug};
 
 use typemap::TypeMap;
 use plugin::Extensible;
@@ -107,7 +107,7 @@ fn write_with_body(mut res: HttpResponse<Fresh>, mut body: Box<Reader + Send>) -
     res.end()
 }
 
-impl Show for Response {
+impl Debug for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "HTTP/1.1 {} {}\n{}",
             self.status.unwrap_or(status::NotFound),
@@ -117,9 +117,9 @@ impl Show for Response {
     }
 }
 
-impl fmt::String for Response {
+impl fmt::Display for Response {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Show::fmt(self, f)
+        Debug::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
* Replacing `fmt::Show` with `fmt::Debug`, `fmt::String` with `fmt::Display`.
* Replacing `str::StrExt::slice_from` with `&s[start..]` notation.