### PR TITLE
Change installation instructions to use release

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ resolution algorithm by swapping in your own `Chain`.
 If you're using `Cargo`, just add Iron to your `Cargo.toml`:
 
 ```toml
-[dependencies.iron]
+[dependencies]
 
-git = "https://github.com/iron/iron.git"
+iron = "0.0.17"
 ```
 
 Otherwise, just clone this repo, `cargo build`, and the rlib will be in your `target` directory.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you're using `Cargo`, just add Iron to your `Cargo.toml`:
 ```toml
 [dependencies]
 
-iron = "0.0.17"
+iron = "*"
 ```
 
 Otherwise, just clone this repo, `cargo build`, and the rlib will be in your `target` directory.


### PR DESCRIPTION
Users should be using the latest release published to crates.io, rather than master.