### PR TITLE
Fixes around std::io being renamed to std::old_io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ rusti.sh
 /examples/*
 !/examples/*.rs
 Cargo.lock
+.cargo

--- a/src/iron.rs
+++ b/src/iron.rs
@@ -1,7 +1,7 @@
 //! Exposes the `Iron` type, the main entrance point of the
 //! `Iron` library.
 
-use std::io::net::ip::{ToSocketAddr, SocketAddr};
+use std::old_io::net::ip::{ToSocketAddr, SocketAddr};
 use std::os;
 
 pub use hyper::server::Listening;

--- a/src/middleware/test.rs
+++ b/src/middleware/test.rs
@@ -1,5 +1,5 @@
-use std::io::net::ip::ToSocketAddr;
-use std::io::util::NullReader;
+use std::old_io::net::ip::ToSocketAddr;
+use std::old_io::util::NullReader;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -29,7 +29,7 @@
 //! For more information about the modifier system, see
 //! [rust-modifier](https://github.com/reem/rust-modifier).
 
-use std::io::{File, MemReader};
+use std::old_io::{File, MemReader};
 use std::path::Path;
 
 use modifier::Modifier;

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -1,7 +1,7 @@
 //! Iron's HTTP Request representation and associated methods.
 
-use std::io::net::ip::SocketAddr;
-use std::io::IoResult;
+use std::old_io::net::ip::SocketAddr;
+use std::old_io::IoResult;
 use std::fmt::{self, Debug};
 
 use hyper::uri::RequestUri::{AbsoluteUri, AbsolutePath};

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,6 @@
 //! Iron's HTTP Response representation and associated methods.
 
-use std::io::{self, IoResult};
+use std::old_io::{self, IoResult};
 use std::fmt::{self, Debug};
 
 use typemap::TypeMap;
@@ -89,7 +89,7 @@ fn write_with_body(mut res: HttpResponse<Fresh>, mut body: Box<Reader + Send>) -
 
     let mut res = try!(res.start());
 
-    // FIXME: Manually inlined io::util::copy
+    // FIXME: Manually inlined old_io::util::copy
     // because Box<Reader + Send> does not impl Reader.
     //
     // Tracking issue: rust-lang/rust#18542
@@ -97,11 +97,11 @@ fn write_with_body(mut res: HttpResponse<Fresh>, mut body: Box<Reader + Send>) -
     loop {
         let len = match body.read(buf) {
             Ok(len) => len,
-            Err(ref e) if e.kind == io::EndOfFile => break,
+            Err(ref e) if e.kind == old_io::EndOfFile => break,
             Err(e) => { return Err(e) },
         };
 
-        try!(res.write(&buf[..len]))
+        try!(res.write_all(&buf[..len]))
     }
 
     res.end()


### PR DESCRIPTION
  - Fixed imports and io:: references
  - Fixed deprecated Writer::write calls to use Writer::write_all