### PR TITLE
(cleanup) Removed the println! that are no longer called

### DIFF
--- a/examples/404.rs
+++ b/examples/404.rs
@@ -7,6 +7,5 @@ fn main() {
     Iron::new(|&: _: &mut Request| {
         Ok(Response::with(status::NotFound))
     }).listen("localhost:3000").unwrap();
-    println!("On 3000");
 }
 

--- a/examples/around.rs
+++ b/examples/around.rs
@@ -58,11 +58,11 @@ fn main() {
     let silent = Iron::new(Logger::new(LoggerMode::Silent).around(Box::new(hello_world)));
     let large = Iron::new(Logger::new(LoggerMode::Large).around(Box::new(hello_world)));
 
-    println!("Starting servers on 2000, 3000, and 4000");
     
-    tiny.listen("localhost:2000").unwrap();
-    silent.listen("localhost:3000").unwrap();
-    large.listen("localhost:4000").unwrap();
-
+    let _tiny_listening = tiny.listen("localhost:2000").unwrap();
+    let _silent_listening = silent.listen("localhost:3000").unwrap();
+    let _large_listening = large.listen("localhost:4000").unwrap();
+    
+    println!("Servers listening on 2000, 3000, and 4000");
 }
 

--- a/examples/around.rs
+++ b/examples/around.rs
@@ -58,10 +58,11 @@ fn main() {
     let silent = Iron::new(Logger::new(LoggerMode::Silent).around(Box::new(hello_world)));
     let large = Iron::new(Logger::new(LoggerMode::Large).around(Box::new(hello_world)));
 
+    println!("Starting servers on 2000, 3000, and 4000");
+    
     tiny.listen("localhost:2000").unwrap();
     silent.listen("localhost:3000").unwrap();
     large.listen("localhost:4000").unwrap();
 
-    println!("Servers listening on 2000, 3000, and 4000");
 }
 

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -45,6 +45,5 @@ fn main() {
     chain.link_before(ErrorProducer);
 
     Iron::new(chain).listen("localhost:3000").unwrap();
-    println!("On 3000");
 }
 

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -10,6 +10,5 @@ fn main() {
     Iron::new(move |&: _: &mut Request | {
         Ok(Response::with((status::Found, Redirect(url.clone()))))
     }).listen("localhost:3000").unwrap();
-    println!("On 3000");
 }
 


### PR DESCRIPTION
 Removed the println! that are no longer called and moved a the more useful one within examples/around.rs above the listen calls.