### PR TITLE
(feat) Add ability to serve over HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ fn main() {
     chain.link((ResponseTime, ResponseTime));
 
     // Kick off serving.
-    Iron::new(chain).listen("localhost:3000").unwrap();
+    Iron::new(chain).http("localhost:3000").unwrap();
 }
 ```
 

--- a/examples/404.rs
+++ b/examples/404.rs
@@ -6,6 +6,6 @@ use iron::status;
 fn main() {
     Iron::new(|&: _: &mut Request| {
         Ok(Response::with(status::NotFound))
-    }).listen("localhost:3000").unwrap();
+    }).http("localhost:3000").unwrap();
 }
 

--- a/examples/around.rs
+++ b/examples/around.rs
@@ -58,11 +58,10 @@ fn main() {
     let silent = Iron::new(Logger::new(LoggerMode::Silent).around(Box::new(hello_world)));
     let large = Iron::new(Logger::new(LoggerMode::Large).around(Box::new(hello_world)));
 
-    
-    let _tiny_listening = tiny.listen("localhost:2000").unwrap();
-    let _silent_listening = silent.listen("localhost:3000").unwrap();
-    let _large_listening = large.listen("localhost:4000").unwrap();
-    
+    let _tiny_listening = tiny.http("localhost:2000").unwrap();
+    let _silent_listening = silent.http("localhost:3000").unwrap();
+    let _large_listening = large.http("localhost:4000").unwrap();
+
     println!("Servers listening on 2000, 3000, and 4000");
 }
 

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -44,6 +44,6 @@ fn main() {
     // Link our error maker.
     chain.link_before(ErrorProducer);
 
-    Iron::new(chain).listen("localhost:3000").unwrap();
+    Iron::new(chain).http("localhost:3000").unwrap();
 }
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,6 +6,6 @@ use iron::status;
 fn main() {
     Iron::new(|&: _: &mut Request| {
         Ok(Response::with((status::Ok, "Hello world!")))
-    }).listen("localhost:3000").unwrap();
+    }).http("localhost:3000").unwrap();
 }
 

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -9,6 +9,6 @@ fn main() {
 
     Iron::new(move |&: _: &mut Request | {
         Ok(Response::with((status::Found, Redirect(url.clone()))))
-    }).listen("localhost:3000").unwrap();
+    }).http("localhost:3000").unwrap();
 }
 

--- a/examples/time.rs
+++ b/examples/time.rs
@@ -32,5 +32,5 @@ fn main() {
     let mut chain = Chain::new(hello_world);
     chain.link_before(ResponseTime);
     chain.link_after(ResponseTime);
-    Iron::new(chain).listen("localhost:3000").unwrap();
+    Iron::new(chain).http("localhost:3000").unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! # use iron::status;
 //! Iron::new(|&: req: &mut Request| {
 //!     Ok(Response::with((status::Ok, "Hello World!")))
-//! }).listen("localhost:3000").unwrap();
+//! }).http("localhost:3000").unwrap();
 //! ```
 //!
 //! ## Design Philosophy
@@ -87,7 +87,7 @@ pub use middleware::{BeforeMiddleware, AfterMiddleware, AroundMiddleware,
                      Handler, Chain};
 
 // Server
-pub use iron::Iron;
+pub use iron::{Iron, Protocol};
 
 // Extensions
 pub use typemap::TypeMap;


### PR DESCRIPTION
This adds a security property to iron::Iron, defaulting to 'Insecure'.
Setting it to 'Secure' and specifying certificate and key paths allows
the server to use HTTPS.

Also fix a FIXME in Request::from_http now that HTTPS connections
are possible.