### PR TITLE
(feat) Set content type automatically for based on file extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ plugin = "*"
 modifier = "*"
 error = "*"
 log = "*"
+conduit-mime-types = "*"
+lazy_static = "*"
 
 [dev-dependencies]
 time = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(test, feature(test, box_syntax))]
 
 #![deny(missing_docs)]
-#![feature(unboxed_closures, core, os, io, net, path)]
+#![feature(unboxed_closures, core, os, io, net, path, file_path)]
 
 //! The main crate for Iron.
 //!
@@ -75,6 +75,9 @@ extern crate "typemap" as tmap;
 extern crate plugin;
 extern crate "error" as err;
 extern crate url;
+extern crate "conduit-mime-types" as mime_types;
+#[macro_use]
+extern crate lazy_static;
 
 // Request + Response
 pub use request::{Request, Url};


### PR DESCRIPTION
Taken from iron/static#14. This pull should not be accepted as-is. `mime_types::Types::new()` loads a media type lookup table from a JSON file, and that probably shouldn't be done every request for obvious performance reasons. Any ideas as to where we can store this object? In `Iron` somehow? Maybe a static (singleton generating) method?