### PR TITLE
Added ContentLength header in Modifier implementation for File

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -62,7 +62,7 @@ impl Modifier<Response> for String {
 impl Modifier<Response> for Vec<u8> {
     #[inline]
     fn modify(self, res: &mut Response) {
-        (self.len() as u64).modify(res);
+        res.headers.set(headers::ContentLength(self.len() as u64));
         res.body = Some(Box::new(MemReader::new(self)) as Box<Reader + Send>);
     }
 }
@@ -81,13 +81,6 @@ impl<'a> Modifier<Response> for &'a [u8] {
     }
 }
 
-impl Modifier<Response> for u64 {
-    #[inline]
-    fn modify(self, res: &mut Response) {
-        res.headers.set(headers::ContentLength(self));
-    }
-}
-
 impl Modifier<Response> for File {
     #[inline]
     fn modify(self, res: &mut Response) {
@@ -97,7 +90,7 @@ impl Modifier<Response> for File {
         //     .and_then(|ct| { res.set_mut(ct) });
 
         if let Ok(stat) = self.stat() {
-            stat.size.modify(res);
+            res.headers.set(headers::ContentLength(stat.size));
         }
 
         res.body = Some(Box::new(self) as Box<Reader + Send>);


### PR DESCRIPTION
Added Modifier impl for u64 to set ContentLength header. Also added ContentLength header in impl Modifier for File.

Not sure about panicking if failed to retrieve stat(). According to [this](http://man7.org/linux/man-pages/man2/stat.2.html#ERRORS) it is possible to get error even if file is valid.

Also not sure about having modifier for u64. Actually the main thing I need is to have ContentLength header for file in [iron/static](https://github.com/iron/static). 