### PR TITLE
Remove the fs feature gate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(test, feature(test, box_syntax))]
 
 #![deny(missing_docs)]
-#![feature(unboxed_closures, core, os, io, net, fs, path)]
+#![feature(unboxed_closures, core, os, io, net, path)]
 
 //! The main crate for Iron.
 //!


### PR DESCRIPTION
Removing `#![feature(fs)]` makes iron finally compile on my machine.