### PR TITLE
(fix) Add a second request lifetime for hyper changes.

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -146,7 +146,7 @@ where H: headers::Header + headers::HeaderFormat {
     }
 }
 
-impl<'a, H> Modifier<Request<'a>> for Header<H>
+impl<'a, 'b, H> Modifier<Request<'a, 'b>> for Header<H>
 where H: headers::Header + headers::HeaderFormat {
     fn modify(self, res: &mut Request) {
         res.headers.set(self.0);


### PR DESCRIPTION
The request body type now has two lifetime parameters.

Fixes #313