### PR TITLE
(fix) remove quotations from crate names & change hyphens to underscores

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,12 +64,12 @@
 
 // Third party packages
 extern crate hyper;
-extern crate "typemap" as tmap;
+extern crate typemap as tmap;
 extern crate plugin;
-extern crate "error" as err;
+extern crate error as err;
 extern crate url;
 extern crate num_cpus;
-extern crate "conduit-mime-types" as mime_types;
+extern crate conduit_mime_types as mime_types;
 #[macro_use]
 extern crate lazy_static;
 
@@ -131,7 +131,7 @@ pub mod typemap {
 
 /// Re-exports from the Modifier crate.
 pub mod modifier {
-    extern crate "modifier" as modfier;
+    extern crate modifier as modfier;
     pub use self::modfier::*;
 }
 


### PR DESCRIPTION
Rustc [removed support for quotes in crate names](https://github.com/rust-lang/rust/pull/23786) and hyphens a few days ago. This PR fixes those issues.