### PR TITLE
[feature(core)] is not necessary on the latest rustc.

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -1,4 +1,3 @@
-#![feature(core)]
 extern crate iron;
 extern crate time;
 


### PR DESCRIPTION
rustc : rustc 1.0.0-nightly (2e3b0c051 2015-04-01) (built 2015-04-01)
I have worked in
* [feature(core)] is removed because it is not necessary anymore.