### PR TITLE
(doc) use shields.io badges for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Iron
 ====
 
-[![Build Status](https://img.shields.io/travis/iron/iron.svg?style=flat-square)](https://travis-ci.org/iron/iron)
-[![Crates.io Status](https://img.shields.io/crates/v/iron.svg?style=flat-square)](https://crates.io/crates/iron)
+[![Build Status](https://secure.travis-ci.org/iron/iron.svg?branch=master)](https://travis-ci.org/iron/iron)
+[![Crates.io Status](http://meritbadge.herokuapp.com/iron)](https://crates.io/crates/iron)
 
 > Extensible, Concurrency Focused Web Development in Rust.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Iron
 ====
 
-[![Build Status](https://secure.travis-ci.org/iron/iron.png?branch=master)](https://travis-ci.org/iron/iron)
-[![Crates.io Status](http://meritbadge.herokuapp.com/iron)](https://crates.io/crates/iron)
+[![Build Status](https://img.shields.io/travis/iron/iron.svg?style=flat-square)](https://travis-ci.org/iron/iron)
+[![Crates.io Status](https://img.shields.io/crates/v/iron.svg?style=flat-square)](https://crates.io/crates/iron)
 
 > Extensible, Concurrency Focused Web Development in Rust.
 


### PR DESCRIPTION
It drives me a little nuts seeing badges with slight differences in style on a project's README.  
This PR uses [shields.io](http://shields.io) to style the Build and Crates.io badges more consistently.