### PR TITLE
(fix) Reexport hyper::status::StatusClass

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ pub mod modifier {
 pub mod status {
     pub use hyper::status::StatusCode as Status;
     pub use hyper::status::StatusCode::*;
+    pub use hyper::status::StatusClass;
 }
 
 /// HTTP Methods


### PR DESCRIPTION
Exported as iron::status::StatusClass;

Needed to support iron/logger#57