### PR TITLE
Hyper 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,11 @@ authors = [
 name = "iron"
 path = "src/lib.rs"
 
+[features]
+default = ["ssl"]
+ssl = ["hyper/ssl"]
+
 [dependencies]
-hyper = "0.5"
 typemap = "*"
 url = "*"
 plugin = "*"
@@ -31,6 +34,9 @@ conduit-mime-types = "*"
 lazy_static = "*"
 num_cpus = "*"
 
+[dependencies.hyper]
+version = "0.6"
+default-features = false
+
 [dev-dependencies]
 time = "*"
-

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -6,7 +6,7 @@ use std::fmt::{self, Debug};
 
 use hyper::uri::RequestUri::{AbsoluteUri, AbsolutePath};
 use hyper::net::NetworkStream;
-use hyper::http::HttpReader;
+use hyper::http::h1::HttpReader;
 
 use typemap::TypeMap;
 use plugin::Extensible;


### PR DESCRIPTION
Makes SSL a default optional feature. Removes HTTPS-related parts of the API when the feature is disabled - would a runtime panic instead be better?

Note that for the feature to actually be useful, all packages that depend on iron but do not depend on the existence of SSL will need to be updated to use `default-features = false` - so basically all middleware ever.