### PR TITLE
(feat) Add `ChainLink` - the builder pattern for Chain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use response::Response;
 
 // Middleware system
 pub use middleware::{BeforeMiddleware, AfterMiddleware, AroundMiddleware,
-                     Handler, Chain};
+                     Handler, Chain, ChainLink};
 
 // Server
 pub use iron::{Iron, Protocol};
@@ -115,7 +115,7 @@ pub type IronResult<T> = Result<T, IronError>;
 /// of the convenience methods in Iron, as well as `Request`, `Response`
 /// `IronResult`, `IronError` and `Iron`.
 pub mod prelude {
-    pub use {Set, Plugin, Chain, Request, Response,
+    pub use {Set, Plugin, Chain, ChainLink, Request, Response,
              IronResult, IronError, Iron};
 }
 


### PR DESCRIPTION
Had a similar problem to #353.

Didn't want to change the type signature on the core Chain impl, so implemented it as a Builder.