### PR TITLE
Manage before middleware error

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -2,7 +2,7 @@ extern crate iron;
 extern crate time;
 
 use iron::prelude::*;
-use iron::{Handler, BeforeMiddleware};
+use iron::{Handler, BeforeMiddleware, AroundMiddleware};
 use iron::status;
 
 use std::error::Error;
@@ -37,19 +37,63 @@ impl Handler for ErrorHandler {
 
 impl BeforeMiddleware for ErrorProducer {
     fn before(&self, _: &mut Request) -> IronResult<()> {
-        Err(IronError::new(StringError("Error".to_string()), status::BadRequest))
+        Err(IronError::new(StringError("Error you cannot access the resource!".to_string()), status::BadRequest))
     }
 }
 
+
+// to handle the Error message by using an AroundMiddleware
+struct LogEnabler;
+
+struct HandlerWithLog<H: Handler> {
+    handler: H
+}
+
+impl AroundMiddleware for LogEnabler {
+
+    fn around(self, handler: Box<Handler>) -> Box<Handler> {
+        Box::new(HandlerWithLog { handler: handler } ) as Box<Handler>
+    }
+}
+ 
+impl <H: Handler> Handler for HandlerWithLog<H> {
+
+    fn handle(&self, req: &mut Request) -> IronResult<Response> {
+    
+        let res = self.handler.handle(req);
+        
+        {
+          match res {
+            Ok(_) => panic!("is not possible!"),
+            Err(IronError {error: ref what_went_wrong, ref response }) => println!("what went wrong: {:?} - response: {:?}", what_went_wrong, response)
+          };          
+        }
+        
+        res
+    }
+}
+
+pub fn get_log_enabled_handler(handler : Box<Handler>) -> Box<Handler> {
+  
+  let use_log = LogEnabler;
+    
+  use_log.around(handler)
+}
+
+
 fn main() {
     // Handler is attached here.
+    
     let mut chain = Chain::new(ErrorHandler);
 
     // Link our error maker.
     chain.link_before(ErrorProducer);
-
+    
+    // enable the tracing of the error by using an AroundMiddleware
+    let logged_handler = get_log_enabled_handler(Box::new(chain));
+    
     println!("server running at http://localhost:3000");
     println!("try it by opening the url in a browser or by: 'curl -v http://localhost:3000', 'curl -v http://localhost:3000/any_other_destination/same_bad_request'");
-    Iron::new(chain).http("localhost:3000").unwrap();
+    Iron::new(logged_handler).http("localhost:3000").unwrap();
 }
 

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -48,6 +48,8 @@ fn main() {
     // Link our error maker.
     chain.link_before(ErrorProducer);
 
+    println!("server running at http://localhost:3000");
+    println!("try it by opening the url in a browser or by: 'curl -v http://localhost:3000', 'curl -v http://localhost:3000/any_other_destination/same_bad_request'");
     Iron::new(chain).http("localhost:3000").unwrap();
 }
 

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -1,14 +1,13 @@
 extern crate iron;
-extern crate time;
 
 use iron::prelude::*;
-use iron::{Handler, BeforeMiddleware, AroundMiddleware};
+use iron::{Handler, BeforeMiddleware, AfterMiddleware};
 use iron::status;
 
 use std::error::Error;
 use std::fmt::{self, Debug};
 
-struct ErrorHandler;
+struct NeverCalledHandler;
 struct ErrorProducer;
 
 #[derive(Debug)]
@@ -24,7 +23,7 @@ impl Error for StringError {
     fn description(&self) -> &str { &*self.0 }
 }
 
-impl Handler for ErrorHandler {
+impl Handler for NeverCalledHandler {
     fn handle(&self, _: &mut Request) -> IronResult<Response> {
         // This is never called!
         //
@@ -37,63 +36,32 @@ impl Handler for ErrorHandler {
 
 impl BeforeMiddleware for ErrorProducer {
     fn before(&self, _: &mut Request) -> IronResult<()> {
-        Err(IronError::new(StringError("Error you cannot access the resource!".to_string()), status::BadRequest))
+        Err(IronError::new(StringError("You cannot access the resource!".to_string()), status::BadRequest))
     }
 }
 
-
-// to handle the Error message by using an AroundMiddleware
-struct LogEnabler;
-
-struct HandlerWithLog<H: Handler> {
-    handler: H
-}
-
-impl AroundMiddleware for LogEnabler {
-
-    fn around(self, handler: Box<Handler>) -> Box<Handler> {
-        Box::new(HandlerWithLog { handler: handler } ) as Box<Handler>
+// the error is simply printed on stdout and returned as is
+struct ErrorHandler;
+impl AfterMiddleware for ErrorHandler {
+    fn catch(&self, _: &mut Request, err: IronError) -> IronResult<Response> {
+      println!("handled the error: {:?}",err.error);
+      Err(err)
     }
 }
- 
-impl <H: Handler> Handler for HandlerWithLog<H> {
-
-    fn handle(&self, req: &mut Request) -> IronResult<Response> {
-    
-        let res = self.handler.handle(req);
-        
-        {
-          match res {
-            Ok(_) => panic!("is not possible!"),
-            Err(IronError {error: ref what_went_wrong, ref response }) => println!("what went wrong: {:?} - response: {:?}", what_went_wrong, response)
-          };          
-        }
-        
-        res
-    }
-}
-
-pub fn get_log_enabled_handler(handler : Box<Handler>) -> Box<Handler> {
-  
-  let use_log = LogEnabler;
-    
-  use_log.around(handler)
-}
-
 
 fn main() {
     // Handler is attached here.
-    
-    let mut chain = Chain::new(ErrorHandler);
+
+    let mut chain = Chain::new(NeverCalledHandler);
 
     // Link our error maker.
     chain.link_before(ErrorProducer);
-    
-    // enable the tracing of the error by using an AroundMiddleware
-    let logged_handler = get_log_enabled_handler(Box::new(chain));
-    
+
+    // enable the tracing of the error by catching it with an AfterMiddleware
+    chain.link_after(ErrorHandler);
+
     println!("server running at http://localhost:3000");
     println!("try it by opening the url in a browser or by: 'curl -v http://localhost:3000', 'curl -v http://localhost:3000/any_other_destination/same_bad_request'");
-    Iron::new(logged_handler).http("localhost:3000").unwrap();
+    Iron::new(chain).http("localhost:3000").unwrap();
 }
 


### PR DESCRIPTION
Hi, 

I added 

* a message to help the user running the example
* an around middleware to trace on the console the error message catched by the server
