### PR TITLE
Fix prelude doc formatting.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,9 @@ pub mod error;
 /// The Result alias used throughout Iron and in clients of Iron.
 pub type IronResult<T> = Result<T, IronError>;
 
-/// A module meant to be glob imported when using Iron, for instance:
+/// A module meant to be glob imported when using Iron.
+///
+/// For instance:
 ///
 /// ```
 /// use iron::prelude::*;


### PR DESCRIPTION
Previously, the 'for ' part blended into the description on the main page.
By putting it on a new line, the index is better formatted.