### PR TITLE
(doc) Remove warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //! use iron::status;
 //!
 //! fn main() {
-//!     Iron::new(|req: &mut Request| {
+//!     Iron::new(|_: &mut Request| {
 //!         Ok(Response::with((status::Ok, "Hello World!")))
 //!     }).http("localhost:3000").unwrap();
 //! }


### PR DESCRIPTION
```
warning: unused variable: `req`, #[warn(unused_variables)] on by default
Iron::new(|req: &mut Request| {
```