### PR TITLE
(refactor) Added return to link functions on Chain

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -151,30 +151,37 @@ impl Chain {
     ///
     /// Middleware that have a Before and After piece should have a constructor
     /// which returns both as a tuple, so it can be passed directly to link.
-    pub fn link<B, A>(&mut self, link: (B, A))
+    pub fn link<B, A>(&mut self, link: (B, A)) -> &mut Chain
     where A: AfterMiddleware, B: BeforeMiddleware {
         let (before, after) = link;
         self.befores.push(Box::new(before) as Box<BeforeMiddleware>);
         self.afters.push(Box::new(after) as Box<AfterMiddleware>);
+        self
     }
 
     /// Link a `BeforeMiddleware` to the `Chain`, after all previously linked
     /// `BeforeMiddleware`.
-    pub fn link_before<B>(&mut self, before: B) where B: BeforeMiddleware {
+    pub fn link_before<B>(&mut self, before: B) -> &mut Chain
+    where B: BeforeMiddleware {
         self.befores.push(Box::new(before) as Box<BeforeMiddleware>);
+        self
     }
 
     /// Link a `AfterMiddleware` to the `Chain`, after all previously linked
     /// `AfterMiddleware`.
-    pub fn link_after<A>(&mut self, after: A) where A: AfterMiddleware {
+    pub fn link_after<A>(&mut self, after: A) -> &mut Chain
+    where A: AfterMiddleware {
         self.afters.push(Box::new(after) as Box<AfterMiddleware>);
+        self
     }
 
     /// Apply an `AroundMiddleware` to the `Handler` in this `Chain`.
-    pub fn around<A>(&mut self, around: A) where A: AroundMiddleware {
+    pub fn around<A>(&mut self, around: A) -> &mut Chain
+    where A: AroundMiddleware {
         let mut handler = self.handler.take().unwrap();
         handler = around.around(handler);
         self.handler = Some(handler);
+        self
     }
 }
 


### PR DESCRIPTION
This commit modifies `Chain.link()`, `Chain.link_before()`, `Chain.link_after()`, and `Chain.around()` to return a reference to the current `Chain`. This allows the, ahem, "chaining" of calls to these functions, which is slightly more ergonomic than the way things are now.

All tests pass locally with these changes, but I'm not sure how to best add tests to check this specific change.

This addresses issue #353.