### PR TITLE
(refactor) Rename around() to link_around()

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -176,7 +176,16 @@ impl Chain {
     }
 
     /// Apply an `AroundMiddleware` to the `Handler` in this `Chain`.
+    ///
+    /// Note: This function is being renamed `link_around()`, and will
+    /// eventually be removed.
     pub fn around<A>(&mut self, around: A) -> &mut Chain
+    where A: AroundMiddleware {
+        self.link_around(around)
+    }
+
+    /// Apply an `AroundMiddleware` to the `Handler` in this `Chain`.
+    pub fn link_around<A>(&mut self, around: A) -> &mut Chain
     where A: AroundMiddleware {
         let mut handler = self.handler.take().unwrap();
         handler = around.around(handler);


### PR DESCRIPTION
This is a small change that just renames `Chain.around()` to `Chain.link_around()`, for consistency with the other linking functions.