### PR TITLE
(fix) Add re-export of hyper::server::Listening [Fixes #406]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub use middleware::{BeforeMiddleware, AfterMiddleware, AroundMiddleware,
                      Handler, Chain};
 
 // Server
-pub use iron::{Iron, Protocol};
+pub use iron::{Iron, Protocol, Listening};
 
 // Extensions
 pub use typemap::TypeMap;


### PR DESCRIPTION
This re-exports `hyper::server::Listening` as `iron::Listening`. Since iron returns an `Listening` in `Iron::http()` and `Iron::https()` it should re-export it to make it available for client code.