### PR TITLE
Update doc about default number of threads

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -102,7 +102,7 @@ impl<H: Handler> Iron<H> {
     /// The thread returns a guard that will automatically join with the parent
     /// once it is dropped, blocking until this happens.
     ///
-    /// Defaults to a threadpool of size `2 * num_cpus`.
+    /// Defaults to a threadpool of size `8 * num_cpus`.
     ///
     /// ## Panics
     ///
@@ -121,7 +121,7 @@ impl<H: Handler> Iron<H> {
     /// The thread returns a guard that will automatically join with the parent
     /// once it is dropped, blocking until this happens.
     ///
-    /// Defaults to a threadpool of size `2 * num_cpus`.
+    /// Defaults to a threadpool of size `8 * num_cpus`.
     ///
     /// ## Panics
     ///


### PR DESCRIPTION
To make it consistent with what the [doc](https://github.com/iwinux/iron/blob/165daff62dfc6c0050f6706633c7a3f08b7b8dfe/src/iron.rs#L105) says:

> Defaults to a threadpool of size `2 * num_cpus`.