### PR TITLE
Generic SSL Interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "iron"
 path = "src/lib.rs"
 
 [features]
-default = ["ssl", "openssl"]
+default = ["ssl"]
 ssl = ["hyper/ssl"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "iron"
 path = "src/lib.rs"
 
 [features]
-default = ["ssl"]
+default = ["ssl", "openssl"]
 ssl = ["hyper/ssl"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ extern crate conduit_mime_types as mime_types;
 #[macro_use]
 extern crate lazy_static;
 
-#[cfg(feature = "openssl")]
+#[cfg(feature = "ssl")]
 extern crate openssl;
 // Request + Response
 pub use request::{Request, Url};
@@ -84,7 +84,10 @@ pub use middleware::{BeforeMiddleware, AfterMiddleware, AroundMiddleware,
                      Handler, Chain};
 
 // Server
-pub use iron::{Iron, Protocol};
+pub use iron::{Iron, Protocol, ProtocolHandler, HttpProtocolHandler};
+
+#[cfg(feature = "ssl")]
+pub use iron::HttpsProtocolHandler;
 
 // Extensions
 pub use typemap::TypeMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ extern crate conduit_mime_types as mime_types;
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(feature = "openssl")]
+extern crate openssl;
 // Request + Response
 pub use request::{Request, Url};
 pub use response::Response;


### PR DESCRIPTION
This allows for the SSL Context to be created by the end developer. (Built to allow custom SNI handling.)