### PR TITLE
(feat) Make WriteBody require Send, shortening and clarifying bounds.

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -52,7 +52,7 @@ impl Modifier<Response> for Mime {
     }
 }
 
-impl Modifier<Response> for Box<WriteBody + Send> {
+impl Modifier<Response> for Box<WriteBody> {
     #[inline]
     fn modify(self, res: &mut Response) {
         res.body = Some(self);


### PR DESCRIPTION
A non-Send WriteBody is not very useful, since Response requires a Send
WriteBody. While this is slightly less general since WriteBody can no
longer be used fully in other contexts it makes for simpler and more
likely-to-be-correct generic uses of it.

Technically a breaking change, but I can hardly imagine there is any
actual breakage as a result of this change