### PR TITLE
(feat) Add BodyReader wrapper

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -30,6 +30,7 @@
 //! [rust-modifier](https://github.com/reem/rust-modifier).
 
 use std::fs::File;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use modifier::Modifier;
@@ -39,7 +40,7 @@ use hyper::mime::Mime;
 use {status, headers, Request, Response, Set, Url};
 
 use mime_types;
-use response::WriteBody;
+use response::{WriteBody, BodyReader};
 
 lazy_static! {
     static ref MIME_TYPES: mime_types::Types = mime_types::Types::new().unwrap();
@@ -56,6 +57,13 @@ impl Modifier<Response> for Box<WriteBody> {
     #[inline]
     fn modify(self, res: &mut Response) {
         res.body = Some(self);
+    }
+}
+
+impl <R: io::Read + Send + 'static> Modifier<Response> for BodyReader<R> {
+    #[inline]
+    fn modify(self, res: &mut Response) {
+        res.body = Some(Box::new(self));
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -35,6 +35,9 @@ impl<'a> Write for ResponseBody<'a> {
     }
 }
 
+/// Wrapper type to set `Read`ers as response bodies
+pub struct BodyReader<R: Send>(pub R);
+
 /// A trait which writes the body of an HTTP response.
 pub trait WriteBody: Send {
     /// Writes the body to the provided `ResponseBody`.
@@ -74,6 +77,12 @@ impl WriteBody for File {
 impl WriteBody for Box<io::Read + Send> {
     fn write_body(&mut self, res: &mut ResponseBody) -> io::Result<()> {
         io::copy(self, res).map(|_| ())
+    }
+}
+
+impl <R: io::Read + Send> WriteBody for BodyReader<R> {
+    fn write_body(&mut self, res: &mut ResponseBody) -> io::Result<()> {
+        io::copy(&mut self.0, res).map(|_| ())
     }
 }
 


### PR DESCRIPTION
This allows to easily set a `Read`er as response body without dealing with `as Box<WriteBody>` shenanigans.

# Example
```rust
let reader = io::empty();
Response::with(BodyReader(reader));
```

I'm not sure if we actually want to implement it this way.
The pros are that we can avoid annoying type wrestling and double-boxing.
The cons are that we need to introduce intermediate types like `BodyReader`.