### PR TITLE
Update hyper to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "0.1"
 num_cpus = "0.2"
 
 [dependencies.hyper]
-version = "0.7"
+version = "0.8"
 default-features = false
 
 [dev-dependencies]


### PR DESCRIPTION
One particular annoyance is that hyper 0.7 pulls in a version of mime that unnecessarily pulls in serde as a dependency.