### PR TITLE
Don't deny any lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/7853871?s=128", html_favicon_url = "https://avatars0.githubusercontent.com/u/7853871?s=256", html_root_url = "http://ironframework.io/core/iron")]
 #![cfg_attr(test, deny(warnings))]
-#![deny(missing_docs)]
+#![warn(missing_docs)]
 
 //! The main crate for Iron.
 //!


### PR DESCRIPTION
Don't deny any lints

This makes iron forward-compatible with lint changes.

(We can't use deny(missing_docs) for test builds due to bug rust-lang/rust/issues/24584.)

This is for the same reason as rust-lang/cargo/pull/2622. It is of course best to wait for their lead and see what other rust & cargo devs think.

Iron is now privileged to be part of rust's integration tests. As a counter gesture, please don't have iron break on lint changes and improvements.