### PR TITLE
Update url to 1.1 and hyper to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ssl = ["hyper/ssl"]
 
 [dependencies]
 typemap = "0.3"
-url = "1.0"
+url = "1.1"
 plugin = "0.2"
 modifier = "0.1"
 error = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ssl = ["hyper/ssl"]
 
 [dependencies]
 typemap = "0.3"
-url = "0.5"
+url = "1.0"
 plugin = "0.2"
 modifier = "0.1"
 error = "0.1"
@@ -35,7 +35,7 @@ lazy_static = "0.1"
 num_cpus = "0.2"
 
 [dependencies.hyper]
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dev-dependencies]

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -67,42 +67,41 @@ impl Url {
     /// Create a `Url` from a `rust-url` `Url`.
     pub fn from_generic_url(raw_url: url::Url) -> Result<Url, String> {
         // Create an Iron URL by extracting the special scheme data.
-        match raw_url.cannot_be_a_base() {
-            false => {
-                // Extract the port as a 16-bit unsigned integer.
-                let port: u16 = match raw_url.port_or_known_default() {
-                    // If explicitly defined or has a known default, unwrap it.
-                    Some(port) => port,
+        if raw_url.cannot_be_a_base() {
+            Err(format!("Not a special scheme: `{}`", raw_url.scheme()))
+        } else {
+            // Extract the port as a 16-bit unsigned integer.
+            let port: u16 = match raw_url.port_or_known_default() {
+                // If explicitly defined or has a known default, unwrap it.
+                Some(port) => port,
 
-                    // Otherwise, use the scheme's default port.
-                    None => return Err(format!("Invalid special scheme: `{}`",
-                                                    raw_url.scheme())),
-                };
-                // Map empty usernames to None.
-                let username = match raw_url.username() {
-                    "" => None,
-                    _ => Some(raw_url.username())
-                };
-                // Map empty passwords to None.
-                let password = match raw_url.password() {
-                    None => None,
-                    Some(ref x) if x.is_empty() => None,
-                    Some(password) => Some(password)
-                };
-                Ok(Url {
-                    scheme: raw_url.scheme().to_string(),
-                    // `unwrap` is safe here because urls that cannot be a base don't have a host
-                    host: raw_url.host().unwrap().to_owned(),
-                    port: port,
-                    // `unwrap` is safe here because urls that can be a base will have `Some`.
-                    path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
-                    username: username.map(str::to_string),
-                    password: password.map(str::to_string),
-                    query: raw_url.query().map(str::to_string),
-                    fragment: raw_url.fragment().map(str::to_string),
-                })
-            },
-            true => Err(format!("Not a special scheme: `{}`", raw_url.scheme()))
+                // Otherwise, use the scheme's default port.
+                None => return Err(format!("Invalid special scheme: `{}`",
+                                                raw_url.scheme())),
+            };
+            // Map empty usernames to None.
+            let username = match raw_url.username() {
+                "" => None,
+                _ => Some(raw_url.username())
+            };
+            // Map empty passwords to None.
+            let password = match raw_url.password() {
+                None => None,
+                Some(ref x) if x.is_empty() => None,
+                Some(password) => Some(password)
+            };
+            Ok(Url {
+                scheme: raw_url.scheme().to_string(),
+                // `unwrap` is safe here because urls that cannot be a base don't have a host
+                host: raw_url.host().unwrap().to_owned(),
+                port: port,
+                // `unwrap` is safe here because urls that can be a base will have `Some`.
+                path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
+                username: username.map(str::to_string),
+                password: password.map(str::to_string),
+                query: raw_url.query().map(str::to_string),
+                fragment: raw_url.fragment().map(str::to_string),
+            })
         }
     }
 

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -95,11 +95,11 @@ impl Url {
                     host: raw_url.host().unwrap().to_owned(),
                     port: port,
                     // `unwrap` is safe here because urls that can be a base will have `Some`.
-                    path: raw_url.path_segments().unwrap().map(|x| x.to_string()).collect(),
-                    username: username.map(|s| s.to_string()),
-                    password: password.map(|s| s.to_string()),
-                    query: raw_url.query().map(|s| s.to_string()),
-                    fragment: raw_url.fragment().map(|s| s.to_string()),
+                    path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
+                    username: username.map(str::to_string),
+                    password: password.map(str::to_string),
+                    query: raw_url.query().map(str::to_string),
+                    fragment: raw_url.fragment().map(str::to_string),
                 })
             },
             true => Err(format!("Not a special scheme: `{}`", raw_url.scheme()))

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -94,7 +94,8 @@ impl Url {
                     // `unwrap` is safe here because urls that cannot be a base don't have a host
                     host: raw_url.host().unwrap().to_owned(),
                     port: port,
-                    path: raw_url.path_segments().into_iter().flat_map(|x| x).map(|x| x.to_string()).collect(),
+                    // `unwrap` is safe here because urls that can be a base will have `Some`.
+                    path: raw_url.path_segments().unwrap().map(|x| x.to_string()).collect(),
                     username: username.map(|s| s.to_string()),
                     password: password.map(|s| s.to_string()),
                     query: raw_url.query().map(|s| s.to_string()),

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -3,7 +3,7 @@
 use url::{Host, RelativeSchemeData};
 use url::{whatwg_scheme_type_mapper};
 use url::{self, SchemeData, SchemeType};
-use url::format::{PathFormatter, UserInfoFormatter};
+use url::format::PathFormatter;
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
@@ -143,11 +143,17 @@ impl fmt::Display for Url {
         try!(self.scheme.fmt(formatter));
         try!("://".fmt(formatter));
 
+        let username = self.username.as_ref().map_or("", |s| &**s);
+        let password = self.password.as_ref().map(|s| &**s);
         // Write the user info.
-        try!(write!(formatter, "{}", UserInfoFormatter {
-            username: self.username.as_ref().map_or("", |s| &**s),
-            password: self.password.as_ref().map(|s| &**s)
-        }));
+        if !username.is_empty() || password.is_some() {
+            try!(formatter.write_str(username));
+            if let Some(password) = password {
+                try!(formatter.write_str(":"));
+                try!(formatter.write_str(password));
+            }
+            try!(formatter.write_str("@"));
+        }
 
         // Write the host.
         try!(self.host.fmt(formatter));

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -3,7 +3,6 @@
 use url::{Host, RelativeSchemeData};
 use url::{whatwg_scheme_type_mapper};
 use url::{self, SchemeData, SchemeType};
-use url::format::PathFormatter;
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
@@ -166,7 +165,14 @@ impl fmt::Display for Url {
         }
 
         // Write the path.
-        try!(write!(formatter, "{}", PathFormatter { path: &self.path }));
+        if self.path.is_empty() {
+            try!(formatter.write_str("/"));
+        } else {
+            for path_part in self.path.iter() {
+                try!("/".fmt(formatter));
+                try!(path_part.fmt(formatter));
+            }
+        }
 
         // Write the query.
         match self.query {


### PR DESCRIPTION
Hi! ❤️ So the url crate now has a 1.0 version out that has some breaking changes, and hyper 0.9 is out, which uses url 1.0, and I think because hyper does `pub use url::Url`, iron can't update hyper without updating url. So I decided to give it a try!

I put most of the details of the relevant changes in [the commit message for the last commit](https://github.com/iron/iron/commit/bca05d75107e7bb3896064e78633334d663d5045). There might be better ways to do the conversions between Iron's Url and url's Url, but because the url crate now does a lot of checks and coordination in the setters, I didn't think it would be a good idea to set the fields of the Url directly.

If @SimonSapin has time, he might want to code review this and make sure I'm not missing anything :)
