### PR TITLE
Hold onto rust-url Url in iron Url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ssl = ["hyper/ssl"]
 
 [dependencies]
 typemap = "0.3"
-url = "1.0"
+url = "1.1"
 plugin = "0.2"
 modifier = "0.1"
 error = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ssl = ["hyper/ssl"]
 
 [dependencies]
 typemap = "0.3"
-url = "0.5"
+url = "1.0"
 plugin = "0.2"
 modifier = "0.1"
 error = "0.1"
@@ -35,7 +35,7 @@ lazy_static = "0.1"
 num_cpus = "0.2"
 
 [dependencies.hyper]
-version = "0.8"
+version = "0.9"
 default-features = false
 
 [dev-dependencies]

--- a/examples/simple_routing.rs
+++ b/examples/simple_routing.rs
@@ -26,7 +26,7 @@ impl Router {
 
 impl Handler for Router {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
-        match self.routes.get(&req.url.path.join("/")) {
+        match self.routes.get(&req.url.path().join("/")) {
             Some(handler) => handler.handle(req),
             None => Ok(Response::with(status::NotFound))
         }

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -67,42 +67,41 @@ impl Url {
     /// Create a `Url` from a `rust-url` `Url`.
     pub fn from_generic_url(raw_url: url::Url) -> Result<Url, String> {
         // Create an Iron URL by extracting the special scheme data.
-        match raw_url.cannot_be_a_base() {
-            false => {
-                // Extract the port as a 16-bit unsigned integer.
-                let port: u16 = match raw_url.port_or_known_default() {
-                    // If explicitly defined or has a known default, unwrap it.
-                    Some(port) => port,
+        if raw_url.cannot_be_a_base() {
+            Err(format!("Not a special scheme: `{}`", raw_url.scheme()))
+        } else {
+            // Extract the port as a 16-bit unsigned integer.
+            let port: u16 = match raw_url.port_or_known_default() {
+                // If explicitly defined or has a known default, unwrap it.
+                Some(port) => port,
 
-                    // Otherwise, use the scheme's default port.
-                    None => return Err(format!("Invalid special scheme: `{}`",
-                                                    raw_url.scheme())),
-                };
-                // Map empty usernames to None.
-                let username = match raw_url.username() {
-                    "" => None,
-                    _ => Some(raw_url.username())
-                };
-                // Map empty passwords to None.
-                let password = match raw_url.password() {
-                    None => None,
-                    Some(ref x) if x.is_empty() => None,
-                    Some(password) => Some(password)
-                };
-                Ok(Url {
-                    scheme: raw_url.scheme().to_string(),
-                    // `unwrap` is safe here because urls that cannot be a base don't have a host
-                    host: raw_url.host().unwrap().to_owned(),
-                    port: port,
-                    // `unwrap` is safe here because urls that can be a base will have `Some`.
-                    path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
-                    username: username.map(str::to_string),
-                    password: password.map(str::to_string),
-                    query: raw_url.query().map(str::to_string),
-                    fragment: raw_url.fragment().map(str::to_string),
-                })
-            },
-            true => Err(format!("Not a special scheme: `{}`", raw_url.scheme()))
+                // Otherwise, use the scheme's default port.
+                None => return Err(format!("Invalid special scheme: `{}`",
+                                                raw_url.scheme())),
+            };
+            // Map empty usernames to None.
+            let username = match raw_url.username() {
+                "" => None,
+                _ => Some(raw_url.username())
+            };
+            // Map empty passwords to None.
+            let password = match raw_url.password() {
+                None => None,
+                Some(ref x) if x.is_empty() => None,
+                Some(password) => Some(password)
+            };
+            Ok(Url {
+                scheme: raw_url.scheme().to_string(),
+                // `unwrap` is safe here because urls that cannot be a base don't have a host
+                host: raw_url.host().unwrap().to_owned(),
+                port: port,
+                // `unwrap` is safe here because urls that can be a base will have `Some`.
+                path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
+                username: username.map(str::to_string),
+                password: password.map(str::to_string),
+                query: raw_url.query().map(str::to_string),
+                fragment: raw_url.fragment().map(str::to_string),
+            })
         }
     }
 

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -95,11 +95,11 @@ impl Url {
                     host: raw_url.host().unwrap().to_owned(),
                     port: port,
                     // `unwrap` is safe here because urls that can be a base will have `Some`.
-                    path: raw_url.path_segments().unwrap().map(|x| x.to_string()).collect(),
-                    username: username.map(|s| s.to_string()),
-                    password: password.map(|s| s.to_string()),
-                    query: raw_url.query().map(|s| s.to_string()),
-                    fragment: raw_url.fragment().map(|s| s.to_string()),
+                    path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
+                    username: username.map(str::to_string),
+                    password: password.map(str::to_string),
+                    query: raw_url.query().map(str::to_string),
+                    fragment: raw_url.fragment().map(str::to_string),
                 })
             },
             true => Err(format!("Not a special scheme: `{}`", raw_url.scheme()))

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -45,7 +45,10 @@ pub struct Url {
     ///
     /// `None` if the `#` character was not part of the input.
     /// Otherwise, a possibly empty, percent encoded string.
-    pub fragment: Option<String>
+    pub fragment: Option<String>,
+
+    /// The generic rust-url that corresponds to this Url
+    generic_url: url::Url,
 }
 
 impl Url {
@@ -82,13 +85,13 @@ impl Url {
             // Map empty usernames to None.
             let username = match raw_url.username() {
                 "" => None,
-                _ => Some(raw_url.username())
+                _ => Some(raw_url.username().to_string())
             };
             // Map empty passwords to None.
             let password = match raw_url.password() {
                 None => None,
                 Some(ref x) if x.is_empty() => None,
-                Some(password) => Some(password)
+                Some(password) => Some(password.to_string())
             };
             Ok(Url {
                 scheme: raw_url.scheme().to_string(),
@@ -97,17 +100,18 @@ impl Url {
                 port: port,
                 // `unwrap` is safe here because urls that can be a base will have `Some`.
                 path: raw_url.path_segments().unwrap().map(str::to_string).collect(),
-                username: username.map(str::to_string),
-                password: password.map(str::to_string),
+                username: username,
+                password: password,
                 query: raw_url.query().map(str::to_string),
                 fragment: raw_url.fragment().map(str::to_string),
+                generic_url: raw_url,
             })
         }
     }
 
     /// Create a `rust-url` `Url` from a `Url`.
     pub fn into_generic_url(self) -> url::Url {
-        url::Url::parse(&self.to_string()).unwrap()
+        self.generic_url
     }
 }
 

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -94,7 +94,8 @@ impl Url {
                     // `unwrap` is safe here because urls that cannot be a base don't have a host
                     host: raw_url.host().unwrap().to_owned(),
                     port: port,
-                    path: raw_url.path_segments().into_iter().flat_map(|x| x).map(|x| x.to_string()).collect(),
+                    // `unwrap` is safe here because urls that can be a base will have `Some`.
+                    path: raw_url.path_segments().unwrap().map(|x| x.to_string()).collect(),
                     username: username.map(|s| s.to_string()),
                     password: password.map(|s| s.to_string()),
                     query: raw_url.query().map(|s| s.to_string()),

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -3,7 +3,7 @@
 use url::{Host, RelativeSchemeData};
 use url::{whatwg_scheme_type_mapper};
 use url::{self, SchemeData, SchemeType};
-use url::format::{PathFormatter, UserInfoFormatter};
+use url::format::PathFormatter;
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
@@ -143,11 +143,17 @@ impl fmt::Display for Url {
         try!(self.scheme.fmt(formatter));
         try!("://".fmt(formatter));
 
+        let username = self.username.as_ref().map_or("", |s| &**s);
+        let password = self.password.as_ref().map(|s| &**s);
         // Write the user info.
-        try!(write!(formatter, "{}", UserInfoFormatter {
-            username: self.username.as_ref().map_or("", |s| &**s),
-            password: self.password.as_ref().map(|s| &**s)
-        }));
+        if !username.is_empty() || password.is_some() {
+            try!(formatter.write_str(username));
+            if let Some(password) = password {
+                try!(formatter.write_str(":"));
+                try!(formatter.write_str(password));
+            }
+            try!(formatter.write_str("@"));
+        }
 
         // Write the host.
         try!(self.host.fmt(formatter));

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -117,60 +117,7 @@ impl Url {
 
 impl fmt::Display for Url {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        // Write the scheme.
-        try!(self.scheme.fmt(formatter));
-        try!("://".fmt(formatter));
-
-        let username = self.username.as_ref().map_or("", |s| &**s);
-        let password = self.password.as_ref().map(|s| &**s);
-        // Write the user info.
-        if !username.is_empty() || password.is_some() {
-            try!(formatter.write_str(username));
-            if let Some(password) = password {
-                try!(formatter.write_str(":"));
-                try!(formatter.write_str(password));
-            }
-            try!(formatter.write_str("@"));
-        }
-
-        // Write the host.
-        try!(self.host.fmt(formatter));
-
-        // Write the port if they are not the default ports of 80 for HTTP and 443 for HTTPS.
-        if !((&self.scheme == "http" && self.port == 80) ||
-            (&self.scheme == "https" && self.port == 443)) {
-                try!(":".fmt(formatter));
-                try!(self.port.fmt(formatter));
-        }
-
-        // Write the path.
-        if self.path.is_empty() {
-            try!(formatter.write_str("/"));
-        } else {
-            for path_part in self.path.iter() {
-                try!("/".fmt(formatter));
-                try!(path_part.fmt(formatter));
-            }
-        }
-
-        // Write the query.
-        match self.query {
-            Some(ref query) => {
-                try!("?".fmt(formatter));
-                try!(query.fmt(formatter));
-            },
-            None => ()
-        }
-
-        // Write the fragment.
-        match self.fragment {
-            Some(ref fragment) => {
-                try!("#".fmt(formatter));
-                try!(fragment.fmt(formatter));
-            },
-            None => ()
-        }
-
+        try!(self.generic_url.fmt(formatter));
         Ok(())
     }
 }

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -3,7 +3,6 @@
 use url::{Host, RelativeSchemeData};
 use url::{whatwg_scheme_type_mapper};
 use url::{self, SchemeData, SchemeType};
-use url::format::PathFormatter;
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
@@ -166,7 +165,14 @@ impl fmt::Display for Url {
         }
 
         // Write the path.
-        try!(write!(formatter, "{}", PathFormatter { path: &self.path }));
+        if self.path.is_empty() {
+            try!(formatter.write_str("/"));
+        } else {
+            for path_part in self.path.iter() {
+                try!("/".fmt(formatter));
+                try!(path_part.fmt(formatter));
+            }
+        }
 
         // Write the query.
         match self.query {

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -47,14 +47,14 @@ impl Url {
     }
 
     /// The lower-cased scheme of the URL, typically "http" or "https".
-    pub fn scheme(&self) -> String {
-        self.generic_url.scheme().to_string()
+    pub fn scheme(&self) -> &str {
+        self.generic_url.scheme()
     }
 
     /// The host field of the URL, probably a domain.
-    pub fn host(&self) -> Host {
+    pub fn host(&self) -> Host<&str> {
         // `unwrap` is safe here because urls that cannot be a base don't have a host
-        self.generic_url.host().unwrap().to_owned()
+        self.generic_url.host().unwrap()
     }
 
     /// The connection port.
@@ -68,9 +68,9 @@ impl Url {
     ///
     /// A *non-empty* vector encoding the parts of the URL path.
     /// Empty entries of `""` correspond to trailing slashes.
-    pub fn path(&self) -> Vec<String> {
+    pub fn path(&self) -> Vec<&str> {
         // `unwrap` is safe here because urls that can be a base will have `Some`.
-        self.generic_url.path_segments().unwrap().map(str::to_string).collect()
+        self.generic_url.path_segments().unwrap().collect()
     }
 
     /// The URL username field, from the userinfo section of the URL.
@@ -78,11 +78,11 @@ impl Url {
     /// `None` if the `@` character was not part of the input OR
     /// if a blank username was provided.
     /// Otherwise, a non-empty string.
-    pub fn username(&self) -> Option<String> {
+    pub fn username(&self) -> Option<&str> {
         // Map empty usernames to None.
         match self.generic_url.username() {
             "" => None,
-            username => Some(username.to_string())
+            username => Some(username)
         }
     }
 
@@ -91,12 +91,12 @@ impl Url {
     /// `None` if the `@` character was not part of the input OR
     /// if a blank password was provided.
     /// Otherwise, a non-empty string.
-    pub fn password(&self) -> Option<String> {
+    pub fn password(&self) -> Option<&str> {
         // Map empty passwords to None.
         match self.generic_url.password() {
             None => None,
             Some(ref x) if x.is_empty() => None,
-            Some(password) => Some(password.to_string())
+            Some(password) => Some(password)
         }
     }
 
@@ -104,16 +104,16 @@ impl Url {
     ///
     /// `None` if the `?` character was not part of the input.
     /// Otherwise, a possibly empty, percent encoded string.
-    pub fn query(&self) -> Option<String> {
-        self.generic_url.query().map(str::to_string)
+    pub fn query(&self) -> Option<&str> {
+        self.generic_url.query()
     }
 
     /// The URL fragment.
     ///
     /// `None` if the `#` character was not part of the input.
     /// Otherwise, a possibly empty, percent encoded string.
-    pub fn fragment(&self) -> Option<String> {
-        self.generic_url.fragment().map(str::to_string)
+    pub fn fragment(&self) -> Option<&str> {
+        self.generic_url.fragment()
     }
 }
 
@@ -147,11 +147,11 @@ mod test {
 
     #[test]
     fn test_not_empty_username() {
-        let user = Url::parse("http://john:pass@example.com").unwrap().username();
-        assert_eq!(user.unwrap(), "john");
+        let url = Url::parse("http://john:pass@example.com").unwrap();
+        assert_eq!(url.username().unwrap(), "john");
 
-        let user = Url::parse("http://john:@example.com").unwrap().username();
-        assert_eq!(user.unwrap(), "john");
+        let url = Url::parse("http://john:@example.com").unwrap();
+        assert_eq!(url.username().unwrap(), "john");
     }
 
     #[test]
@@ -162,11 +162,11 @@ mod test {
 
     #[test]
     fn test_not_empty_password() {
-        let pass = Url::parse("http://michael:pass@example.com").unwrap().password();
-        assert_eq!(pass.unwrap(), "pass");
+        let url = Url::parse("http://michael:pass@example.com").unwrap();
+        assert_eq!(url.password().unwrap(), "pass");
 
-        let pass = Url::parse("http://:pass@example.com").unwrap().password();
-        assert_eq!(pass.unwrap(), "pass");
+        let url = Url::parse("http://:pass@example.com").unwrap();
+        assert_eq!(url.password().unwrap(), "pass");
     }
 
     #[test]


### PR DESCRIPTION
Rather than doing so many conversions back and forth.

This builds on #452 and contains 3 commits more than that PR.

Commits eea2bbf and bef95ae are fairly straightforward. eea2bbf gets rid of the extra `rust-url` parse call needed since `rust-url` 1.0 to get back to a `rust-url` `Url`. bef95ae uses `rust-url`'s display implementation on the stored `rust-url` `Url` for the `iron` `Url`'s display trait-- all the tests still pass.

3a9b322 may be a step too far-- I'm happy to remove it if so. It changes the public API of `iron` `Url` to have methods instead of the struct fields, and those methods mostly just delegate to the `rust-url` `Url`. I'm not sure if this is what you had in mind or not!