### PR TITLE
make RedirectRaw's field public to allow construction

### DIFF
--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -187,7 +187,7 @@ impl Modifier<Response> for Redirect {
 }
 
 /// A modifier for creating redirect responses.
-pub struct RedirectRaw(String);
+pub struct RedirectRaw(pub String);
 
 impl Modifier<Response> for RedirectRaw {
     fn modify(self, res: &mut Response) {


### PR DESCRIPTION
RedirectRaw is necessary to allow redirection to urls which don't have special schemes (and therefore are incompatible with Redirect) such as oob:// and steam://

This patch allows construction of RedirectRaw by making the inner field public.