### PR TITLE
Add methods to launch an http or https server on a bound Listener

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 
 pub use hyper::server::Listening;
 use hyper::server::Server;
-use hyper::net::{NetworkListener, HttpListener, Fresh, NetworkStream};
+use hyper::net::{NetworkListener, HttpListener, Fresh};
 #[cfg(feature = "ssl")]
 use hyper::net::{HttpsListener};
 


### PR DESCRIPTION
Another attempt at #386. Please also see #415 which addresses the same issue.

I tried to keep things so no hyper internals are exposed, and I refactored a little to try to reduce the repetition that otherwise snuck in.

Example usage:

``` rust
extern crate iron;

use iron::prelude::*;
use iron::status;
use std::net::TcpListener;

fn main() {
    fn hello_world(_: &mut Request) -> IronResult<Response> {
        Ok(Response::with((status::Ok, String::from("Hello World!"))))
    }

    let listener = TcpListener::bind("0.0.0.0:80").unwrap();

    let _i = Iron::new(hello_world).http_on(listener).unwrap();
}
```
