### PR TITLE
Improve conversion of iron::Url from/to url::Url

### DIFF
--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -42,18 +42,9 @@ impl Url {
     }
 
     /// Create a `rust-url` `Url` from a `Url`.
+    #[deprecated(since="0.5.0", note="use `into` from the `Into` trait instead")]
     pub fn into_generic_url(self) -> url::Url {
         self.generic_url
-    }
-
-    /// Return an immutable pointer to the underlying `rust-url` `Url`.
-    pub fn generic_url(&self) -> &url::Url {
-        &self.generic_url
-    }
-
-    /// Return a mutable pointer to the underlying `rust-url` `Url`.
-    pub fn generic_url_mut(&mut self) -> &mut url::Url {
-        &mut self.generic_url
     }
 
     /// The lower-cased scheme of the URL, typically "http" or "https".
@@ -134,6 +125,19 @@ impl fmt::Display for Url {
     }
 }
 
+impl Into<url::Url> for Url {
+    fn into(self) -> url::Url { self.generic_url }
+}
+
+impl AsRef<url::Url> for Url {
+    fn as_ref(&self) -> &url::Url { &self.generic_url }
+}
+
+impl AsMut<url::Url> for Url {
+    fn as_mut(&mut self) -> &mut url::Url { &mut self.generic_url }
+}
+
+
 #[cfg(test)]
 mod test {
     use super::Url;
@@ -191,7 +195,7 @@ mod test {
         let url = Url::parse(url_str).unwrap();
 
         // Convert to a generic URL and check fidelity.
-        let raw_url = url.clone().into_generic_url();
+        let raw_url: ::url::Url = url.clone().into();
         assert_eq!(::url::Url::parse(url_str).unwrap(), raw_url);
 
         // Convert back to an Iron URL and check fidelity.

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -46,6 +46,16 @@ impl Url {
         self.generic_url
     }
 
+    /// Return an immutable pointer to the underlying `rust-url` `Url`.
+    pub fn generic_url(&self) -> &url::Url {
+        &self.generic_url
+    }
+
+    /// Return a mutable pointer to the underlying `rust-url` `Url`.
+    pub fn generic_url_mut(&mut self) -> &mut url::Url {
+        &mut self.generic_url
+    }
+
     /// The lower-cased scheme of the URL, typically "http" or "https".
     pub fn scheme(&self) -> &str {
         self.generic_url.scheme()


### PR DESCRIPTION
When I want to read data from the underlying `url::Url` (either because
it offers a richer API than Iron's URL for my usecases, or because I can
pass it directly into another API), I currently have two choices:

- `let url = request.url.into_generic_url().clone()`. This unnecessarily
  copies data.

- `let url = request.url.into_generic_url()`, which moves `request.url`,
  and do `request.url = iron::Url::from_generic_url(url)` when I'm done,
  to move the generic URL back into the request. This is unnecessarily
  verbose.

Both options are undesirable. Therefore `generic_url`.

I also have similar usecase for `generic_url_mut`. I have a middleware
that modifies a part of the request URL. Currently I'd have to do
similar tricks to do that.