### PR TITLE
(refactor) bump version of `num_cpus` to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ error = "0.1"
 log = "0.3"
 conduit-mime-types = "0.7"
 lazy_static = "0.1"
-num_cpus = "0.2"
+num_cpus = "1.0"
 
 [dependencies.hyper]
 version = "0.9"


### PR DESCRIPTION
In the process of updating the dependencies of another far upstream package that eventually includes iron, I noticed that `num_cpus` had finally stabilized and made a 1.0 release. There were no code changes in the `1.0` release from `0.2.13` (https://github.com/seanmonstar/num_cpus/commit/7aab1fbc30b9bf39e74b0624dc037af694ce4da3)

The tests for iron pass on my machine, with one ignored test??: `test itry!_0 ... ignored`.