### PR TITLE
(doc) Make content type example more idiomatic, add another example for full customization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ default-features = false
 
 [dev-dependencies]
 time = "0.1"
+mime = "0.2"

--- a/examples/content_type.rs
+++ b/examples/content_type.rs
@@ -1,13 +1,46 @@
+#[macro_use]
+extern crate mime;
 extern crate iron;
 
+use std::env;
+
 use iron::prelude::*;
-use iron::mime::Mime;
+use iron::headers::ContentType;
 use iron::status;
 
+// All these variants do the same thing, with more or less options for customization.
+
+fn variant1(_: &mut Request) -> IronResult<Response> {
+    Ok(Response::with((ContentType::json().0, status::Ok, "{}")))
+}
+
+fn variant2(_: &mut Request) -> IronResult<Response> {
+    use iron::mime;
+    let content_type = "application/json".parse::<mime::Mime>().unwrap();
+    Ok(Response::with((content_type, status::Ok, "{}")))
+}
+
+fn variant3(_: &mut Request) -> IronResult<Response> {
+    let content_type = mime!(Application/Json);
+    Ok(Response::with((content_type, status::Ok, "{}")))
+}
+
+fn variant4(_: &mut Request) -> IronResult<Response> {
+    use iron::mime;
+    let content_type = mime::Mime(iron::mime::TopLevel::Application, iron::mime::SubLevel::Json, vec![]);
+    Ok(Response::with((content_type, status::Ok, "{}")))
+}
 
 fn main() {
-    Iron::new(|_: &mut Request| {
-        let content_type = "application/json".parse::<Mime>().unwrap();
-        Ok(Response::with((content_type, status::Ok, "{}")))
-    }).http("localhost:3000").unwrap();
+    let args: Vec<String> = env::args().collect();
+    let variant_index = if args.len() > 1 { args[1].parse().unwrap() } else { 1 };
+    let handler = match variant_index {
+        1 => variant1,
+        2 => variant2,
+        3 => variant3,
+        4 => variant4,
+        _ => panic!("No such variant"),
+    };
+    println!("Using variant{}", variant_index);
+    Iron::new(handler).http("localhost:3000").unwrap();
 }


### PR DESCRIPTION
Make content type example more idiomatic and thereby safe. Not sure if `ContentType::json().0` looks nice, but definitely works without `.unwrap()` since the JSON content type is built-in.

Old example was copied to `examples/content_type_custom.rs` and another alternative added in a comment.