### PR TITLE
Cleanup some clippy lints.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,7 +10,7 @@ pub use hyper::error::Result as HttpResult;
 
 /// The type of Errors inside and when using Iron.
 ///
-/// IronError informs its receivers of two things:
+/// `IronError` informs its receivers of two things:
 ///
 /// * What went wrong
 /// * What to do about it
@@ -36,7 +36,7 @@ pub struct IronError {
 }
 
 impl IronError {
-    /// Create a new IronError from an error and a modifier.
+    /// Create a new `IronError` from an error and a modifier.
     pub fn new<E: Error, M: Modifier<Response>>(e: E, m: M) -> IronError {
         IronError {
             error: Box::new(e),

--- a/src/iron.rs
+++ b/src/iron.rs
@@ -170,7 +170,7 @@ impl<H: Handler> ::hyper::server::Handler for RawHandler<H> {
         *http_res.status_mut() = status::InternalServerError;
 
         // Create `Request` wrapper.
-        match Request::from_http(http_req, self.addr.clone(), &self.protocol) {
+        match Request::from_http(http_req, self.addr, &self.protocol) {
             Ok(mut req) => {
                 // Dispatch the request, write the response back to http_res
                 self.handler.handle(&mut req).unwrap_or_else(|e| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ pub mod prelude {
              IronResult, IronError, Iron};
 }
 
-/// Re-exports from the TypeMap crate.
+/// Re-exports from the `TypeMap` crate.
 pub mod typemap {
     pub use tmap::{TypeMap, Key};
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -15,9 +15,9 @@
 //! [b] -> [b] -> [b] -> [[[[h]]]] -> [a] -> [a] -> [a] -> [a]
 //! ```
 //!
-//! A request first travels through all BeforeMiddleware, then a Response is generated
-//! by the Handler, which can be an arbitrary nesting of AroundMiddleware, then all
-//! AfterMiddleware are called with both the Request and Response. After all AfterMiddleware
+//! A request first travels through all `BeforeMiddleware`, then a Response is generated
+//! by the `Handler`, which can be an arbitrary nesting of `AroundMiddleware`, then all
+//! `AfterMiddleware` are called with both the `Request` and `Response`. After all `AfterMiddleware`
 //! have been fired, the response is written back to the client.
 //!
 //! Iron's error handling system is pragmatic and focuses on tracking two pieces
@@ -107,10 +107,10 @@ pub trait AfterMiddleware: Send + Sync + 'static {
     }
 }
 
-/// AroundMiddleware are used to wrap and replace the `Handler` in a `Chain`.
+/// `AroundMiddleware` are used to wrap and replace the `Handler` in a `Chain`.
 ///
-/// AroundMiddleware produce `Handler`s through their `around` method, which is
-/// called once on insertion into a Chain or can be called manually outside of a
+/// `AroundMiddleware` produce `Handler`s through their `around` method, which is
+/// called once on insertion into a `Chain` or can be called manually outside of a
 /// `Chain`.
 pub trait AroundMiddleware {
     /// Produce a `Handler` from this `AroundMiddleware` given another `Handler`.

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -89,7 +89,7 @@ impl<'a, 'b> Request<'a, 'b> {
 
             AbsolutePath(ref path) => {
                 let url_string = match (version, headers.get::<headers::Host>()) {
-                    (_, Some(ref host)) => {
+                    (_, Some(host)) => {
                         // Attempt to prepend the Host header (mandatory in HTTP/1.1)
                         if let Some(port) = host.port {
                             format!("{}://{}:{}{}", protocol.name(), host.hostname, port, path)

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -96,7 +96,7 @@ impl Url {
         // Map empty passwords to None.
         match self.generic_url.password() {
             None => None,
-            Some(ref x) if x.is_empty() => None,
+            Some(x) if x.is_empty() => None,
             Some(password) => Some(password)
         }
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -116,7 +116,7 @@ impl Response {
         *http_res.headers_mut() = self.headers;
 
         // Default to a 404 if no response code was set
-        *http_res.status_mut() = self.status.clone().unwrap_or(status::NotFound);
+        *http_res.status_mut() = self.status.unwrap_or(status::NotFound);
 
         let out = match self.body {
             Some(body) => write_with_body(http_res, body),


### PR DESCRIPTION
- Markdown in docstrings.
- Remove some needless clones.
- Get rid of pattern matching references to references.