### PR TITLE
Adding a from_str method

### DIFF
--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -1,6 +1,7 @@
 //! HTTP/HTTPS URL type for Iron.
 
 use url::{self, Host};
+use std::str::FromStr;
 use std::fmt;
 
 /// HTTP/HTTPS URL type for Iron.
@@ -137,6 +138,13 @@ impl AsMut<url::Url> for Url {
     fn as_mut(&mut self) -> &mut url::Url { &mut self.generic_url }
 }
 
+impl FromStr for Url {
+    type Err = String;
+    #[inline]
+    fn from_str(input: &str) -> Result<Url, Self::Err> {
+        Ok(Url::parse(input).unwrap())
+    }
+}
 
 #[cfg(test)]
 mod test {

--- a/src/request/url.rs
+++ b/src/request/url.rs
@@ -142,7 +142,7 @@ impl FromStr for Url {
     type Err = String;
     #[inline]
     fn from_str(input: &str) -> Result<Url, Self::Err> {
-        Ok(Url::parse(input).unwrap())
+        Url::parse(input)
     }
 }
 


### PR DESCRIPTION
This is to allow the use of the FromStr trait to create a Url directly from string, and for example use:

    let u = "https://en.wikipedia.org/wiki/Rust_(programming_language)".parse().unwrap();
    let redirect = iron::modifiers::Redirect(u);

instead of:

    let u = iron::Url::parse("https://en.wikipedia.org/wiki/Rust_(programming_language)").unwrap();
    let redirect = iron::modifiers::Redirect(u);
