### PR TITLE
Replace conduit-mime-types dep by mime_guess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,9 @@ native-tls-example = ["hyper-native-tls"]
 typemap = "0.3"
 url = "1.1"
 plugin = "0.2"
+mime_guess = "1.8.1"
 modifier = "0.1"
 log = "0.3"
-conduit-mime-types = "0.7"
-lazy_static = "0.2"
 num_cpus = "1.0"
 hyper = "0.10"
 hyper-native-tls = { version = "0.2", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,7 @@ extern crate typemap as tmap;
 extern crate plugin;
 extern crate url as url_ext;
 extern crate num_cpus;
-extern crate conduit_mime_types as mime_types;
-#[macro_use]
-extern crate lazy_static;
+extern crate mime_guess;
 
 // Request + Response
 pub use request::{Request, Url};


### PR DESCRIPTION
A couple of reasons:

* conduit-mime-types does not look actively maintained, its last commit was 2 years ago
* It depends on the deprecated rustc-serialize for parsing JSON at runtime
* mime_guess uses a compile-time hash map, which means we also don't need lazy_static anymore either

I split it into two commits: The first one adds tests for the existing functionality. The second one replaces the implementation while keeping the tests.

Here's the result of running [cargo tree](https://github.com/sfackler/cargo-tree) before and after:

```diff
@@ -1,6 +1,4 @@
 iron v0.5.1 (file:///Users/rstocker/Projects/rust/iron)
-├── conduit-mime-types v0.7.3
-│   └── rustc-serialize v0.3.24
 ├── hyper v0.10.10
 │   ├── base64 v0.5.2
 │   │   └── byteorder v1.0.0
@@ -23,8 +21,14 @@
 │       │   │   └── matches v0.1.4 (*)
 │       │   └── unicode-normalization v0.1.4
 │       └── matches v0.1.4 (*)
-├── lazy_static v0.2.8
 ├── log v0.3.7 (*)
+├── mime_guess v1.8.1
+│   ├── mime v0.2.3 (*)
+│   ├── phf v0.7.21
+│   │   └── phf_shared v0.7.21
+│   │       ├── siphasher v0.2.2
+│   │       └── unicase v1.4.0 (*)
+│   └── unicase v1.4.0 (*)
 ├── modifier v0.1.0
 ├── num_cpus v1.4.0 (*)
 ├── plugin v0.2.6
```