### PR TITLE
Fix typo in openssl example

### DIFF
--- a/examples/https.rs
+++ b/examples/https.rs
@@ -8,7 +8,7 @@
 //
 // ```bash
 // openssl req -x509 -newkey rsa:4096 -nodes -keyout localhost.key -out localhost.crt -days 3650
-// openssl pkcs12 -export -out identity.p12 -inkey localhost.key -in localhost.crt --password mypass
+// openssl pkcs12 -export -out identity.p12 -inkey localhost.key -in localhost.crt -password mypass
 //
 // ```
 


### PR DESCRIPTION
Fixes #547