### PR TITLE
Implement Hyper's .downcast_ref() method on Request

### DIFF
--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -130,6 +130,11 @@ impl<'a, 'b> Request<'a, 'b> {
         })
     }
 
+    /// Get a reference to the underlying `NetworkStream`.
+    pub fn downcast_ref<T: NetworkStream>(&self) -> Option<&T> {
+        self.body.0.get_ref().get_ref().downcast_ref()
+    }
+
     #[cfg(test)]
     pub fn stub() -> Request<'a, 'b> {
         Request {


### PR DESCRIPTION
It is often useful to access the underlying NetworkStream of a Request, e.g. in order to access information from the SSL context such as the client peer certificate when using mutual TLS authentication. This
method uses the same approach as Hyper to access the underlying stream.

Fixes #425