### PR TITLE
(doc) fix ssh key generating command error

### DIFF
--- a/examples/https.rs
+++ b/examples/https.rs
@@ -8,7 +8,7 @@
 //
 // ```bash
 // openssl req -x509 -newkey rsa:4096 -nodes -keyout localhost.key -out localhost.crt -days 3650
-// openssl pkcs12 -export -out identity.p12 -inkey localhost.key -in localhost.crt -password mypass
+// openssl pkcs12 -export -out identity.p12 -inkey localhost.key -in localhost.crt -password pass:mypass
 //
 // ```
 


### PR DESCRIPTION
Hello!

When I wanted to generate a ssh key, I got the following error.

```
Invalid password argument "mypass"
Error getting passwords
```

`pass:` may fix this issue.