### PR TITLE
Revert "README: Add note about maintenance status of iron (#576)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# NOTE: Iron is not actively maintained at the moment, please consider using a different framework
-
 Iron
 ====
 


### PR DESCRIPTION
As Iron is being maintained again and is about to release a new version using hyper 0.12, this note is removed in order to not discourage people from using iron.

This reverts commit 9e5bccb407b1ec8daef51b0d7494627e5c5fc307.

(This PR can be merged whenever we feel confident about releasing iron 0.7.)