### PR TITLE
(fix) Preserve content-length in HEAD response [Fixes #582]

### DIFF
--- a/src/iron.rs
+++ b/src/iron.rs
@@ -182,7 +182,7 @@ impl<H: Handler> Service for IronHandler<H> {
                         .unwrap_or_else(|e| {
                             error!("Error handling:\n{:?}\nError was: {:?}", req, e.error);
                             e.response
-                        }).write_back(&mut http_res)
+                        }).write_back(&mut http_res, req.method)
                 }
                 Err(e) => {
                     error!("Error creating request:\n    {}", e);


### PR DESCRIPTION
This commit resolves #582, where the content-length header of HEAD responses were overwritten as 0. Here my solution was to just pass along the request method to `write_back` and then return Ok if the body is empty and the method is HEAD.

To replicate the original problem and verify my solution, I created an [example project](https://github.com/bplower/iron-verify-issue-582) with a hardcoded response. That response has no body and has a hardcoded content-length of 123. The readme there covers how to run the project, switching between the iron/iron repo and the bplower/iron fork. In short though, running with the latest version of iron gives:

```
curl -s -i --head http://localhost:3000 | grep content-length
content-length: 0
```

and running with the changes in this pull request gives:

```
curl -s -i --head http://localhost:3000 | grep content-length
content-length: 123
```

I did a quick test to see if this would be a drop in fix for https://github.com/TheWaWaR/simple-http-server/issues/16, but it doesn't look like it (there are breaking changes between iron 0.5.0 and 0.6.0).

Let me know if there are any concerns about these changes. If there are I'd be glad to make adjustments.