### PR TITLE
Use source instead of cause in Error trait

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ impl Error for IronError {
         self.error.description()
     }
 
-    fn cause(&self) -> Option<&Error> {
-        self.error.cause()
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.error.source()
     }
 }


### PR DESCRIPTION
This should fix the nightly build (which is currently failing due to the `cause` deprecation warning).