### PR TITLE
Fix query strings

### DIFF
--- a/examples/echo_query.rs
+++ b/examples/echo_query.rs
@@ -1,0 +1,19 @@
+// An example that echoes the query string of the request back as the response.
+//
+// Shows how to read the query string and how to return a response.
+
+extern crate iron;
+
+use iron::prelude::*;
+use iron::StatusCode;
+
+fn echo_request(request: &mut Request) -> IronResult<Response> {
+    match request.url.query() {
+        Some(ref query) => Ok(Response::with((StatusCode::OK, query.clone()))),
+        None => Ok(Response::with((StatusCode::INTERNAL_SERVER_ERROR, "No query string given"))),
+    }
+}
+
+fn main() {
+    Iron::new(echo_request).http("localhost:3000");
+}

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -90,6 +90,8 @@ impl Request {
         let url = {
             let path = uri.path();
 
+            let query = uri.query();
+
             let mut socket_ip = String::new();
             let (host, port) = if let Some(host) = uri.host() {
                 (host, uri.port_part().map(|p| p.as_u16()))
@@ -113,9 +115,17 @@ impl Request {
             };
 
             let url_string = if let Some(port) = port {
-                format!("{}://{}:{}{}", protocol.name(), host, port, path)
+                if let Some(query) = query {
+                    format!("{}://{}:{}{}?{}", protocol.name(), host, port, path, query)
+                } else {
+                    format!("{}://{}:{}{}", protocol.name(), host, port, path)
+                }
             } else {
-                format!("{}://{}{}", protocol.name(), host, path)
+                if let Some(query) = query {
+                    format!("{}://{}{}?{}", protocol.name(), host, path, query)
+                } else {
+                    format!("{}://{}{}", protocol.name(), host, path)  
+                }
             };
 
             match Url::parse(&url_string) {


### PR DESCRIPTION
This PR fixes iron completely ignoring query strings.

I guess the regression was introduced with some changes in the hyper `uri` module that no longer seems to include the query string in the `path` section of the request URL. I did not have time to look into the exact cause yet, though.