### PR TITLE
(doc) Fix usage of status on response timer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ extern crate iron;
 extern crate time;
 
 use iron::prelude::*;
-use iron::{typemap, AfterMiddleware, BeforeMiddleware};
+use iron::{status, typemap, AfterMiddleware, BeforeMiddleware};
 use time::precise_time_ns;
 
 struct ResponseTime;
@@ -39,7 +39,7 @@ impl AfterMiddleware for ResponseTime {
 }
 
 fn hello_world(_: &mut Request) -> IronResult<Response> {
-    Ok(Response::with((iron::StatusCode::OK, "Hello World")))
+    Ok(Response::with((status::Ok, "Hello World")))
 }
 
 fn main() {


### PR DESCRIPTION
Hi,

I was interested in getting going with Iron and gave your example code a try. I noticed that when I tried to use the Response timer example, I ran into an error with the way status code was imported and then consumed. I've made a change to the README that fixes this issue. Hopefully this will help someone in the future :)

