### PR TITLE
Fix outdated hyper-native-tls in 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ modifier = "0.1"
 log = "0.3"
 num_cpus = "1.0"
 hyper = "0.10"
-hyper-native-tls = { version = "0.2", optional = true }
+hyper-native-tls = { version = "0.3", optional = true }
 
 [dev-dependencies]
 time = "0.1"


### PR DESCRIPTION
The first commit contains the fix in-of itself, the following two fix the CI builds on newer `rustc`s.

Ref: https://github.com/thecoshman/http/issues/85
Ref: #584