### PR TITLE
Put query string into request URL

### DIFF
--- a/iron/src/request/mod.rs
+++ b/iron/src/request/mod.rs
@@ -56,13 +56,13 @@ pub struct Request {
 
 impl Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(writeln!(f, "Request {{"));
+        writeln!(f, "Request {{")?;
 
-        try!(writeln!(f, "    url: {:?}", self.url));
-        try!(writeln!(f, "    method: {:?}", self.method));
-        try!(writeln!(f, "    local_addr: {:?}", self.local_addr));
+        writeln!(f, "    url: {:?}", self.url)?;
+        writeln!(f, "    method: {:?}", self.method)?;
+        writeln!(f, "    local_addr: {:?}", self.local_addr)?;
 
-        try!(write!(f, "}}"));
+        write!(f, "}}")?;
         Ok(())
     }
 }
@@ -88,7 +88,7 @@ impl Request {
         ) = req.into_parts();
 
         let url = {
-            let path = uri.path();
+            let path = uri.path_and_query().expect("expected path and query but found None").as_str();
 
             let mut socket_ip = String::new();
             let (host, port) = if let Some(host) = uri.host() {
@@ -213,6 +213,17 @@ mod test {
             .expect("A valid Iron request");
 
         assert_eq!(iron_request.url.host(), Domain("my-host"));
+    }
+
+    #[test]
+    fn test_request_with_query_string() {
+        let mut hyper_request = HttpRequest::new(Body::empty());
+        *hyper_request.uri_mut() = "http://my-host/path?param=value".parse().unwrap();
+
+        let iron_request = Request::from_http(hyper_request, None, &Protocol::http())
+            .expect("A valid Iron request");
+
+        assert_eq!(iron_request.url.query(), Some("param=value"));
     }
 
     #[test]

--- a/iron/src/request/url.rs
+++ b/iron/src/request/url.rs
@@ -124,7 +124,7 @@ impl Url {
 
 impl fmt::Display for Url {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        try!(self.generic_url.fmt(formatter));
+        self.generic_url.fmt(formatter)?;
         Ok(())
     }
 }

--- a/iron/src/response.rs
+++ b/iron/src/response.rs
@@ -150,7 +150,7 @@ fn write_with_body(res: &mut HttpResponse<Body>, mut body: Box<dyn WriteBody>) -
         .insert(headers::CONTENT_TYPE, content_type);
 
     let mut body_contents: Vec<u8> = vec![];
-    try!(body.write_body(&mut body_contents));
+    body.write_body(&mut body_contents)?;
     *res.body_mut() = Body::from(body_contents);
     Ok(())
 }


### PR DESCRIPTION
For some reason query strings were no longer being taken into consideration
and the routes would get no query string value at all if they wanted to.
So this fixes #617 and adds a test to ensure it won't come back.

Several compilation errors related to try! macro were fixed as well.