### PR TITLE
(doc) fix broken logger link

### DIFF
--- a/logger/README.md
+++ b/logger/README.md
@@ -35,9 +35,9 @@ fn no_op_handler(_: &mut Request) -> IronResult<Response> {
 
 Logger is a part of Iron's [core bundle](https://github.com/iron/core).
 
-Logger emits request and response information using standard rust [log facade](https://doc.rust-lang.org/log/log/index.html), formatted with default format or a custom format string.
+Logger emits request and response information using standard rust [log facade](https://docs.rs/log/0.4.8/log/), formatted with the default format or a custom format string.
 
-Format strings can specify fields to be logged (ANSI terminal colors and attributes is no longer supported since [#82](https://github.com/iron/logger/issues/82)).
+Format strings can specify fields to be logged (ANSI terminal colors and attributes are no longer supported as of [#82](https://github.com/iron/logger/issues/82)).
 
 ## Installation
 
@@ -60,9 +60,9 @@ you can build a local copy with `make doc`.
 
 ## Log implementations
 
-To actually log anything, you will need to use some log implementation that will deliver the logs to your desired location, like standard error output, a file or log collecting service. This is not responsibility of iron-logger alone. There are numerous such implementations to choose from, from simple ones that just write to standard error like [env_logger](https://crates.io/crates/env_logger), more configurable ones like [simplelog](https://crates.io/crates/simplelog) to ultimate solutions like [slog](https://crates.io/crates/slog). You can find more on [crates.io](https://crates.io/keywords/logging).
+To actually log anything, you will need to use some log implementation that will deliver the logs to your desired location, like standard error output, a file, or a log collecting service. This is not the responsibility of iron-logger alone. There are numerous such implementations to choose from, from simple ones that just write to standard error like [env_logger](https://crates.io/crates/env_logger), to more configurable ones like [simplelog](https://crates.io/crates/simplelog), to ultimate solutions like [slog](https://crates.io/crates/slog). You can find more on [crates.io](https://crates.io/keywords/logging).
 
-If you are looking for turn-key solution, just follow example from [env_logger](https://doc.rust-lang.org/log/env_logger/).
+If you are looking for a turn-key solution, just follow the example in [env_logger](https://docs.rs/env_logger/0.7.1/env_logger/).
 
 ## Get Help
 


### PR DESCRIPTION
Two links point to the old rust doc urls. This PR updates those to their newer docs.rs urls. Additionally, fixed some grammar here and there.