### PR TITLE
Fix 'examples' and their warnings

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "iron-exmaples"
+name = "iron-examples"
 version = "0.1.0"
 publish = false
 workspace = ".."

--- a/iron/src/request/mod.rs
+++ b/iron/src/request/mod.rs
@@ -56,13 +56,13 @@ pub struct Request {
 
 impl Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(writeln!(f, "Request {{"));
+        writeln!(f, "Request {{")?;
 
-        try!(writeln!(f, "    url: {:?}", self.url));
-        try!(writeln!(f, "    method: {:?}", self.method));
-        try!(writeln!(f, "    local_addr: {:?}", self.local_addr));
+        writeln!(f, "    url: {:?}", self.url)?;
+        writeln!(f, "    method: {:?}", self.method)?;
+        writeln!(f, "    local_addr: {:?}", self.local_addr)?;
 
-        try!(write!(f, "}}"));
+        write!(f, "}}")?;
         Ok(())
     }
 }

--- a/iron/src/request/url.rs
+++ b/iron/src/request/url.rs
@@ -124,7 +124,7 @@ impl Url {
 
 impl fmt::Display for Url {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        try!(self.generic_url.fmt(formatter));
+        self.generic_url.fmt(formatter)?;
         Ok(())
     }
 }

--- a/iron/src/response.rs
+++ b/iron/src/response.rs
@@ -150,7 +150,7 @@ fn write_with_body(res: &mut HttpResponse<Body>, mut body: Box<dyn WriteBody>) -
         .insert(headers::CONTENT_TYPE, content_type);
 
     let mut body_contents: Vec<u8> = vec![];
-    try!(body.write_body(&mut body_contents));
+    body.write_body(&mut body_contents)?;
     *res.body_mut() = Body::from(body_contents);
     Ok(())
 }


### PR DESCRIPTION
Some typos and depreacation warnings addressed.