### PR TITLE
(doc) Fixed modifiers remote link

### DIFF
--- a/iron/src/modifiers.rs
+++ b/iron/src/modifiers.rs
@@ -42,7 +42,7 @@
 //!
 //! The modifiers are applied depending on their type. Currently the easiest
 //! way to see how different types are used as modifiers, take a look at [the
-//! source code](https://github.com/iron/iron/blob/master/src/modifiers.rs).
+//! source code](https://github.com/iron/iron/blob/master/iron/src/modifiers.rs).
 //!
 //! For more information about the modifier system, see
 //! [rust-modifier](https://github.com/reem/rust-modifier).


### PR DESCRIPTION
**Current Behavior**
The comments on `modifiers.rs` point to a deprecated (404) URL of the remote `modifiers.rs` file
https://github.com/iron/iron/issues/618

**New Behavior**
The comments on `modifiers.rs` point the correct URL